### PR TITLE
tk283

### DIFF
--- a/scielomanager/journalmanager/tests.py
+++ b/scielomanager/journalmanager/tests.py
@@ -820,7 +820,6 @@ class LoggedInViewsTest(TestCase):
 
     @with_sample_journal
     def test_journal_trash(self):
-        from journalmanager.views import get_user_collections
         response = self.client.get(reverse('trash.listing'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['trashed_docs'].object_list), 0)
@@ -831,7 +830,6 @@ class LoggedInViewsTest(TestCase):
 
         response = self.client.get(reverse('trash.listing'))
         self.assertEqual(len(response.context['trashed_docs'].object_list), 1)
-
 
 class JournalRestAPITest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Erro:

O erro de memcached acontece no momento de alterações em qualquer item que esteja relacionado com o UserCollections?.

Motivo:

Para que a infra-estrutura de cache funcione corretamente invalidando e esquentando o cache incluindo os relacionamento, deve-se ter uma herança para CachingMixin? na classe e um manager para CachingManager?, a classe Auth.User não utiliza essa infra-estrutura por ser uma classe built in, porém seus relacionamento utilizam.

Maiores detalhes sobre: ​https://github.com/jbalogh/django-cache-machine/issues/1

Solução:

A solução encontrada foi invalidar o cache para os relacionamentos que utilizam a infra-etrutura de cache.
