### PR TITLE
Adicionado filtro nos endpoints journals e issues, da api. 

### DIFF
--- a/scielomanager/api/resources.py
+++ b/scielomanager/api/resources.py
@@ -43,6 +43,22 @@ class IssueResource(ModelResource):
         resource_name = 'issues'
         allowed_methods = ['get', ]
 
+    def build_filters(self, filters=None):
+        """
+        Custom filter that retrieves data by the collection's name_slug.
+        """
+        if filters is None:
+            filters = {}
+
+        orm_filters = super(IssueResource, self).build_filters(filters)
+
+        if 'collection' in filters:
+            issues = Issue.objects.filter(
+                journal__collections__name_slug=filters['collection'])
+            orm_filters['pk__in'] = issues
+
+        return orm_filters
+
 
 class CollectionResource(ModelResource):
     class Meta:
@@ -101,6 +117,22 @@ class JournalResource(ModelResource):
         filtering = {
             'is_trashed': ('exact',),
         }
+
+    def build_filters(self, filters=None):
+        """
+        Custom filter that retrieves data by the collection's name_slug.
+        """
+        if filters is None:
+            filters = {}
+
+        orm_filters = super(JournalResource, self).build_filters(filters)
+
+        if 'collection' in filters:
+            journals = Journal.objects.filter(
+                collections__name_slug=filters['collection'])
+            orm_filters['pk__in'] = journals
+
+        return orm_filters
 
     def dehydrate_missions(self, bundle):
         return [(mission.language.iso_code, mission.description)

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -99,6 +99,11 @@ class JournalCustomManager(AppCustomManager):
 
         return recents
 
+    def all_by_collection(self, collection, is_available=True):
+        objects_all = self.available(is_available).filter(
+            collections=collection)
+        return objects_all
+
 
 class SectionCustomManager(AppCustomManager):
 
@@ -111,10 +116,9 @@ class SectionCustomManager(AppCustomManager):
 
 class IssueCustomManager(AppCustomManager):
 
-    def all_by_user(self, user, is_available=True):
-        user_collections = get_default_user_collections(user.pk)
+    def all_by_collection(self, collection, is_available=True):
         objects_all = self.available(is_available).filter(
-            collections__in=[uc.collection for uc in user_collections]).distinct()
+            journal__collections=collection)
         return objects_all
 
 

--- a/scielomanager/journalmanager/tests/tests.py
+++ b/scielomanager/journalmanager/tests/tests.py
@@ -938,6 +938,15 @@ class JournalRestAPITest(TestCase):
         response = self.client.delete('/api/v1/journals/%s/' % journal.pk)
         self.assertEqual(response.status_code, 405)
 
+    def test_list_all_by_collection(self):
+        import json
+        journal = self._makeOne()
+        response = self.client.get('/api/v1/journals/?collection=brasil')
+        self.assertEqual(response.status_code, 200)
+
+        response_as_py = json.loads(response.content)
+        self.assertEqual(len(response_as_py), 2)
+
 
 class CollectionRestAPITest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Adicionado um novo manager para Issue, que retorna todos os issues de uma determinada coleção. 
Este não está sendo usado ainda mas talves seja útil.

Exemplo:
  http://localhost:8000/api/v1/issues/?format=json&collection=brasil
