### PR TITLE
Bug #355 - O campo `título temático` do formulário de fascículo não pode ser obrigatório

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/add_issue.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_issue.html
@@ -18,13 +18,11 @@
   <span class="label">{% trans "Issue Information" %}</span>
   <div class="well">
     <table id="titleformset" class="table table-bordered table-striped">
-      <thead>
-        <tr>
-          <th>{% trans "Thematic Title" %}</th>
-          <th>{% trans "Language" %}</th>
-        </tr>
-      </thead>
       <tbody>
+        <tr>
+          <td>{% trans "Thematic Title" %}</td>
+          <td>{% trans "Language" %}</td>
+        </tr>
         {% for form in titleformset.forms %}
         <tr id="{{ form.prefix }}-row">
           <td>


### PR DESCRIPTION
O título temático já não era obrigatório, mas a interface estava indicando que sim. 
Ajustada a interface.
