### PR TITLE
Bug360 - Section não deve permitir duplicidade

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/add_section.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_section.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block content %}
+
 <form id="section-form" method="POST" action="" enctype="application/x-www-form-urlencoded">
   {% csrf_token %}
 
@@ -29,6 +30,15 @@
   {% endfor %}
   <span class="label">{% trans 'Titles' %}</span>
   <div class="well">
+    {% if messages %}
+      <div class="alert {{ message.tags }}">
+          {% for dict in section_title_formset.errors %}
+              {% for error in dict.values %}
+                  {{ error }}
+              {% endfor %}
+          {% endfor %}
+      </div>
+    {% endif %}
     <table id="section_title_formset" class="table table-bordered table-striped">
     <thead>
       <tr>


### PR DESCRIPTION
Realizado uma validação no método clean do formulário SectionTitleForm para garantir que não exista duplicidade de títulos nas seções de um revista.
