### PR TITLE
Removido o campo Order do formulário Issue

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/add_issue.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_issue.html
@@ -109,18 +109,6 @@
       </div>
     </div>
 
-    <div class="control-group {% if add_form.order.errors %}error{% endif %}">
-      <label for="{{ add_form.order.auto_id }}">
-        <span {% if add_form.order.field.required %}class="req-field"{% endif %}>
-          {% trans add_form.order.label %}
-        </span>
-      </label>
-      <div class="controls">
-        {{ add_form.order }}
-        {% field_help add_form.order.label add_form.order.help_text term-issue-order %}
-      </div>
-    </div>
-
     <div class="control-group {% if add_form.publication_start_month.errors %}error{% endif %}">
       <label for="{{ add_form.publication_start_month.auto_id }}">
         <span {% if add_form.publication_start_month.field.required %}class="req-field"{% endif %}>

--- a/scielomanager/journalmanager/tests/modelfactories.py
+++ b/scielomanager/journalmanager/tests/modelfactories.py
@@ -92,7 +92,6 @@ class IssueFactory(factory.Factory):
     total_documents = 16
     number = factory.Sequence(lambda n: '%s' % n)
     volume = factory.Sequence(lambda n: '%s' % n)
-    order = factory.Sequence(lambda n: int('%s' % n))
     is_trashed = False
     is_press_release = False
     publication_start_month = 9

--- a/scielomanager/journalmanager/tests/tests_forms.py
+++ b/scielomanager/journalmanager/tests/tests_forms.py
@@ -947,7 +947,6 @@ class IssueFormTests(WebTest):
         form['publication_start_month'] = '9'
         form['publication_end_month'] = '11'
         form['publication_year'] = '2012'
-        form['order'] = '201203'
         form['is_marked_up'] = False
         form['editorial_standard'] = 'other'
 
@@ -980,7 +979,6 @@ class IssueFormTests(WebTest):
         form['publication_start_month'] = '9'
         form['publication_end_month'] = '11'
         form['publication_year'] = '2012'
-        form['order'] = '201203'
         form['is_marked_up'] = False
         form['editorial_standard'] = 'other'
 
@@ -1013,7 +1011,6 @@ class IssueFormTests(WebTest):
         form['is_press_release'] = False
         form['publication_end_month'] = '11'
         form['publication_year'] = '2012'
-        form['order'] = '201203'
         form['is_marked_up'] = False
         form['editorial_standard'] = 'other'
 
@@ -1050,7 +1047,6 @@ class IssueFormTests(WebTest):
         form['publication_start_month'] = '9'
         form['publication_end_month'] = '11'
         form['publication_year'] = str(issue.publication_year)
-        form['order'] = '201203'
         form['is_marked_up'] = False
         form['editorial_standard'] = 'other'
 

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -134,6 +134,30 @@ class IssueTests(TestCase):
 
         self.assertEqual(issue.publication_date, expected)
 
+    def test_get_suggested_issue_order_for_first_issue(self):
+        issue = IssueFactory.create(publication_year=2012, volume=2)
+        self.assertEqual(issue._suggest_order(), 1)
+
+    def test_get_suggested_issue_order_having_multiple_issues(self):
+        journal = JournalFactory.create()
+
+        for i in range(1, 6):
+            issue = IssueFactory.create(volume=9,
+                publication_year=2012, journal=journal)
+
+            self.assertEqual(issue._suggest_order(), i)
+
+    def test_get_suggested_issue_order_having_multiple_years(self):
+        journal = JournalFactory.create()
+
+        issue1 = IssueFactory.create(volume=9,
+            publication_year=2012, journal=journal)
+        issue2 = IssueFactory.create(volume=9,
+            publication_year=2011, journal=journal)
+
+        self.assertEqual(issue1._suggest_order(), 1)
+        self.assertEqual(issue2._suggest_order(), 1)
+
 
 class LanguageTests(TestCase):
 
@@ -239,7 +263,8 @@ class JournalTests(TestCase):
 
             issues.append(issue.pk)
 
-        expected_order = [1, 2, 4, 3, 5]
+        issues[2], issues[3] = issues[3], issues[2]  # reordering
+        expected_order = issues
 
         journal.reorder_issues(expected_order, volume=9, publication_year=2012)
 
@@ -256,7 +281,8 @@ class JournalTests(TestCase):
 
             issues.append(issue.pk)
 
-        expected_order = ['1', '2', '4', '3', '5']
+        issues[2], issues[3] = issues[3], issues[2]  # reordering
+        expected_order = [str(i_pk) for i_pk in issues]
 
         journal.reorder_issues(expected_order, volume=9, publication_year=2012)
 


### PR DESCRIPTION
- O campo `order` foi removido do formulário Issue pq agora será controlado de maneira automática pelo sistema. Caso o sistema suponha uma ordem errada, o usuário pode alterar a ordem arrastando elementos da grade de fascículos.
- A reordenação ocorre num contexto transacional
- Adicionado o método Issue._suggest_order que sugere uma ordem para a instância atual de fascículo no issue
