### PR TITLE
Ajuste no grupo de usuário bibliotecário, para visualização de lista de formulários em versão draft

### DIFF
--- a/docs/dev/useraccesslevel.rst
+++ b/docs/dev/useraccesslevel.rst
@@ -1,0 +1,102 @@
+=================
+User Access Level
+=================
+
+Bibliotecário
+=============
+    
+    Grupo de usuários criado para gestão da maioria das funcionalidades do Journal Manager, tais como:
+    Gestão de periódicos, fascículos, seções, instituições, usuário, status da revista, etc.
+
+#.  auth | user | add
+#.  auth | user | change
+#.  auth | user | delete
+#.  journalmanager | issue | add
+#.  journalmanager | issue | change
+#.  journalmanager | issue | delete
+#.  journalmanager | issue | list
+#.  journalmanager | issue title | add
+#.  journalmanager | issue title | change
+#.  journalmanager | issue title | delete
+#.  journalmanager | journal | add
+#.  journalmanager | journal | change
+#.  journalmanager | journal | delete
+#.  journalmanager | journal | list
+#.  journalmanager | journal publication event | add
+#.  journalmanager | journal publication event | change
+#.  journalmanager | journal study area | add
+#.  journalmanager | journal study area | change
+#.  journalmanager | journal study area | delete
+#.  journalmanager | journal title | add
+#.  journalmanager | journal title | change
+#.  journalmanager | journal title | delete
+#.  journalmanager | language | add
+#.  journalmanager | language | change
+#.  journalmanager | language | delete
+#.  journalmanager | pended form | change
+#.  journalmanager | section | add
+#.  journalmanager | section | change
+#.  journalmanager | section | delete
+#.  journalmanager | section | list
+#.  journalmanager | section title | add
+#.  journalmanager | section title | change
+#.  journalmanager | section title | delete
+#.  journalmanager | sponsor | add
+#.  journalmanager | sponsor | change
+#.  journalmanager | sponsor | delete
+#.  journalmanager | sponsor | list
+#.  journalmanager | supplement | add
+#.  journalmanager | supplement | change
+#.  journalmanager | supplement | delete
+
+Técnico SciELO
+==============
+    Grupo de usuários criado para acesso as funcionalidades que fazem parte do trabalho diário dos
+    técnicos de marcação e produção do SciELO, tais como: Gestão de fascículos e seções.
+
+#.  journalmanager | issue | add
+#.  journalmanager | issue | change
+#.  journalmanager | issue | delete
+#.  journalmanager | issue | list
+#.  journalmanager | issue title | add
+#.  journalmanager | issue title | change
+#.  journalmanager | issue title | delete
+#.  journalmanager | journal | list
+#.  journalmanager | section | add
+#.  journalmanager | section | change
+#.  journalmanager | section | delete
+#.  journalmanager | section | list
+
+Técnico Terceiro
+================
+
+    Grupo de usuários criado para acesso as funcionalidades que fazem parte do trabalho diário dos
+    técnicos e empresas terceirizadas que realizam marcação e produção de conteúdos, tais como: 
+    Gestão de fascículos e seções.
+
+#.  journalmanager | issue | add
+#.  journalmanager | issue | change
+#.  journalmanager | issue | delete
+#.  journalmanager | issue | list
+#.  journalmanager | issue title | add
+#.  journalmanager | issue title | change
+#.  journalmanager | journal | list
+#.  journalmanager | section | add
+#.  journalmanager | section | change
+#.  journalmanager | section | delete
+#.  journalmanager | section | list
+
+Estagiário
+==========
+    Grupo de usuários criado para acesso as funcionalidades que fazem parte do trabalho diário dos
+    técnicos e empresas terceirizadas que realizam marcação e produção de conteúdos, tais como: 
+    Gestão de fascículos e seções sem permissão de exclusão de fascículos.
+
+#.  journalmanager | issue | add
+#.  journalmanager | issue | change
+#.  journalmanager | issue | list
+#.  journalmanager | journal | list
+#.  journalmanager | section | add
+#.  journalmanager | section | change
+#.  journalmanager | section | delete
+#.  journalmanager | section | list

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ and design decisions.
    dev/db-diagram
    dev/mockups
    dev/notes
+   dev/useraccesslevel
    dev/exporttoisis
    dev/api
    dev/importscielo


### PR DESCRIPTION
Não houve necessidade de mudanças em código, apenas o ajuste nas permissões concedidas ao grupo "Bibliotecário".

Incluída a permissão: journalmanager | pended form | change
