### PR TITLE
Bug#375 - Seções com o mesmo nome em idiomas diferentes são impedidos de serem criados

### DIFF
--- a/scielomanager/journalmanager/tests/tests_forms.py
+++ b/scielomanager/journalmanager/tests/tests_forms.py
@@ -7,8 +7,10 @@ from django_webtest import WebTest
 from django.core.urlresolvers import reverse
 from django.core import mail
 from django_factory_boy import auth
+from django.test import TestCase
 
 from journalmanager.tests import modelfactories
+from journalmanager import forms
 
 
 HASH_FOR_123 = 'sha1$93d45$5f366b56ce0444bfea0f5634c7ce8248508c9799'
@@ -1478,3 +1480,55 @@ class SearchFormTests(WebTest):
 
         self.assertIn('Funda\xc3\xa7\xc3\xa3o de Amparo a Pesquisa do Estado de S\xc3\xa3o Paulo',
             page.body)
+
+
+class SectionTitleFormValidationTests(TestCase):
+
+    def test_same_titles_in_same_languages_must_be_invalid(self):
+        journal = modelfactories.JournalFactory()
+        language = modelfactories.LanguageFactory.create(iso_code='en',
+                                                         name='english')
+        journal.languages.add(language)
+
+        section = modelfactories.SectionFactory(journal=journal)
+        section.add_title('Original Article', language=language)
+
+        post_dict = {
+            u'titles-INITIAL_FORMS': 0,
+            u'titles-TOTAL_FORMS': 1,
+            u'legacy_code': u'',
+            u'titles-0-language': unicode(language.pk),
+            u'titles-0-title': u'Original Article',
+        }
+
+        section_forms = forms.get_all_section_forms(post_dict,
+            journal=journal, section=section)
+
+        self.assertTrue(section_forms['section_form'].is_valid())
+        self.assertFalse(section_forms['section_title_formset'].is_valid())
+
+    def test_same_titles_in_different_languages_must_be_valid(self):
+        journal = modelfactories.JournalFactory()
+        language = modelfactories.LanguageFactory.create(iso_code='en',
+                                                         name='english')
+        language2 = modelfactories.LanguageFactory.create(iso_code='pt',
+                                                         name='portuguese')
+        journal.languages.add(language)
+        journal.languages.add(language2)
+
+        section = modelfactories.SectionFactory(journal=journal)
+        section.add_title('Original Article', language=language)
+
+        post_dict = {
+            u'titles-INITIAL_FORMS': 0,
+            u'titles-TOTAL_FORMS': 1,
+            u'legacy_code': u'',
+            u'titles-0-language': unicode(language2.pk),
+            u'titles-0-title': u'Original Article',
+        }
+
+        section_forms = forms.get_all_section_forms(post_dict,
+            journal=journal, section=section)
+
+        self.assertTrue(section_forms['section_form'].is_valid())
+        self.assertTrue(section_forms['section_title_formset'].is_valid())

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -497,7 +497,7 @@ def add_collection(request, collection_id):
     """
     Handles existing collections
     """
-    
+
     collection = get_object_or_404(models.Collection, id=collection_id)
 
     if not collection.is_managed_by_user(request.user):
@@ -639,15 +639,12 @@ def add_section(request, journal_id, section_id=None):
         section = get_object_or_404(models.Section, pk=section_id)
         has_relation = section.is_used()
 
-    SectionTitleFormSet = inlineformset_factory(models.Section, models.SectionTitle,
-        form=SectionTitleForm, extra=1, can_delete=True, formset=FirstFieldRequiredFormSet)
+    all_forms = get_all_section_forms(request.POST, journal, section)
 
-    SectionTitleFormSet.form = staticmethod(curry(SectionTitleForm, journal=journal))
+    add_form = all_forms['section_form']
+    section_title_formset = all_forms['section_title_formset']
 
     if request.method == 'POST':
-
-        add_form = SectionForm(request.POST, instance=section)
-        section_title_formset = SectionTitleFormSet(request.POST, instance=section, prefix='titles')
 
         if add_form.is_valid() and section_title_formset.is_valid():
             add_form = add_form.save_all(journal)
@@ -662,10 +659,6 @@ def add_section(request, journal_id, section_id=None):
             return HttpResponseRedirect(reverse('section.index', args=[journal_id]))
         else:
             messages.error(request, MSG_FORM_MISSING)
-
-    else:
-        add_form = SectionForm(instance=section)
-        section_title_formset = SectionTitleFormSet(instance=section, prefix='titles')
 
     return render_to_response('journalmanager/add_section.html', {
                               'add_form': add_form,


### PR DESCRIPTION
O bug era causado por conta de a validação não levar em conta a existência de seções com estado `is_trashed=True`.

Outras melhorias:
- Retirada da view a responsabilidade de instanciação dos forms/formsets necessários para o formulário de Section. Para tal, foi criada a função `forms.get_all_section_forms(post_dict, journal, section)`, que retorna um dicionário com todos os forms/formsets necessários. Esta tarefa visa tornar o código mais testável, diminuindo a responsabilidade da view.
