### PR TITLE
bug386 - Ordenando os usuários pelo username

### DIFF
--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -247,7 +247,7 @@ def user_index(request):
         return HttpResponseRedirect(AUTHZ_REDIRECT_URL)
 
     col_users = models.User.cached_objects.filter(
-        usercollections__collection__in=[collection]).distinct('username')
+        usercollections__collection__in=[collection]).distinct('username').order_by('username')
 
     users = get_paginated(col_users, request.GET.get('page', 1))
 


### PR DESCRIPTION
Foi considerado o nome de usuário como campo de ordenação, pois é o único que é obrigatório no interface do SciELO Manager 
