### PR TITLE
Adicionando o maintenancewindow no memcached

### DIFF
--- a/scielomanager/maintenancewindow/models.py
+++ b/scielomanager/maintenancewindow/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 import caching.base
 
 
-class EventManager(models.Manager):
+class EventManager(caching.base.CachingManager):
 
     def scheduled_events(self, actual_date=date.today()):
         """

--- a/scielomanager/settings.py
+++ b/scielomanager/settings.py
@@ -229,6 +229,9 @@ SECTION_CODE_TOTAL_RANDOM_CHARS = 4
 
 CACHE_PREFIX = 'scielomanager:'
 
+#One day (seconds)
+CACHE_COUNT_TIMEOUT = 84600
+
 CACHES = {
     'default': {
         #'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',


### PR DESCRIPTION
Adicionando o memcached para a app maintenancewindow e ajustado o timeout do cache para um dia.

Outras necessidades encontradas nesse bug:

Devemos atualizar a biblioteca de cacheamento, precisamos decidir como fazer isso, pois a biblioteca na versão que estamos utilizando tem vários bugs que estão solucionados pelo desenvolvedor, porém o mesmo não atualiza com frequência a pypi isso impedi de realizarmos atualizações.

Reparei também que após a atualização com o master da lib django-cache-machine a quantidade de solicitações para o banco de dados diminuiu.

Vou entrar em contato com o desenvolvedor solicitando atualização dessa lib no pypi.
