### PR TITLE
Inclusão de campos de título abreviado, no formulário de periódico

### DIFF
--- a/scielomanager/journalmanager/choices.py
+++ b/scielomanager/journalmanager/choices.py
@@ -67,6 +67,9 @@ PDF_DOWNLOAD = [
 TITLE_CATEGORY = [
     ('paralleltitle', 'Parallel Title'),
     ('other', 'Other'),
+    ('abbrev_scopus', 'Scopus (abbreviated)'),
+    ('abbrev_wos', 'Web of Science (abbreviated)'),
+    ('abbrev_nlm', 'National Library of Medicine (abbreviated)'),
 ]
 
 JOURNAL_PUBLICATION_STATUS = [


### PR DESCRIPTION
Foram adicionados os valores, ao arquivo `journalmanager/choices.py`:
- `abbrev_scopus`
- `abbrev_wos`
- `abbrev_nlm`

(fixes #395)
