### PR TITLE
Proposta de layout para os Press Releases

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/pressrelease_dashboard.html
+++ b/scielomanager/journalmanager/templates/journalmanager/pressrelease_dashboard.html
@@ -14,42 +14,38 @@
 
 {% block content %}
 
-<div class="row-fluid show-grid">
-  <div class="span8">
-   <a class="btn btn-primary" href="{% url prelease.add journal.id %}">{% trans 'New regular press release' %}</a>
-   <a class="btn btn-primary" href="{% url prelease.add journal.id %}">{% trans 'New for ahead of print articles' %}</a>
+<ul class="nav nav-tabs">
+  <li>
+    <div class="btn-group" style="margin-right: 10px">
+      <button class="btn btn-primary">{% trans 'New' %}</button>
+      <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+      <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><a href="{% url prelease.add journal.id %}">{% trans 'New regular press release' %}</a></li>
+        <li><a href="{% url prelease.add journal.id %}">{% trans 'New for ahead of print articles' %}</a></li>
+      </ul>
+    </div>
+  </li>
+  <li class="active"><a href="#tab1" data-toggle="tab">{% trans 'Press Release of Issue' %}</a></li>
+  <li><a href="#tab2" data-toggle="tab">{% trans 'Press Release of Article' %}</a></li>
+  <li><a href="#tab3" data-toggle="tab">{% trans 'Press Release of Ahead' %}</a></li>
+  <li style="float:right; margin-button: 2px">{% simple_pagination objects_pr %}</li>
+</ul>
+
+<div class="tab-content">
+  <div class="tab-pane active" id="tab1">
+    {% include "include_press_release/issue.html" %}
   </div>
-  <div class="span2">
-    {% simple_pagination objects_pr %}
+
+  <div class="tab-pane" id="tab2">
+    {% include "include_press_release/article.html" %}
+  </div>
+
+  <div class="tab-pane" id="tab3">
+    {% include "include_press_release/ahead.html" %}
   </div>
 </div>
-
-<table class="table table-striped _listings">
-  <thead>
-    <tr>
-      <th>{% trans 'Press Release' %}</th>
-      <th>{% trans 'Issue' %}</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for item in objects_pr.object_list %}
-    <tr>
-      <td>
-        <h4>
-          <a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a>
-        </h4>
-      </td>
-      <td>
-        {{ item.issue }}
-      </td>
-    </tr>
-   {% empty %}
-    <tr>
-      <td colspan="2">{% trans 'There are no items.' %}</td>
-    </tr>
-    {% endfor %}
-  <tbody>
-</table>
 
 {% pagination objects_pr %}
 

--- a/scielomanager/templates/base_lv1.html
+++ b/scielomanager/templates/base_lv1.html
@@ -111,7 +111,7 @@
     </ul>
   </div>
 
-  <div class="nav pull-right">
+  <div class="nav pull-right" style="margin-bottom: 0px;">
     <form id="search-form" action="" method="get">
       <select id="list_model" class="list-model" name="list_model">
         {% if perms.journalmanager.list_journal %}

--- a/scielomanager/templates/include_press_release/ahead.html
+++ b/scielomanager/templates/include_press_release/ahead.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+<table class="table table-striped _listings">
+  <thead>
+    <tr>
+      <th>{% trans 'Press Release' %}</th>
+      <th>{% trans 'Issue' %}</th>
+      <th>{% trans 'DOI' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in objects_pr.object_list %}
+    <tr>
+      <td>
+          <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
+          <small>(<a href="#">{% trans 'Todos os títulos' %}</a>)</small>
+      </td>
+      <td>
+        {{ item.issue }}
+      </td>
+      <td>
+        {{ item.doi|default:"-" }}
+      </td>
+    </tr>
+   {% empty %}
+    <tr>
+      <td colspan="2">{% trans 'There are no items.' %}</td>
+    </tr>
+    {% endfor %}
+  <tbody>
+</table>

--- a/scielomanager/templates/include_press_release/article.html
+++ b/scielomanager/templates/include_press_release/article.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+<table class="table table-striped _listings">
+  <thead>
+    <tr>
+      <th>{% trans 'Press Release' %}</th>
+      <th>{% trans 'Issue' %}</th>
+      <th>{% trans 'DOI' %}</th>
+      <th>{% trans 'PID of Article' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in objects_pr.object_list %}
+    <tr>
+      <td>
+          <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
+          <small>(<a href="#">{% trans 'Todos os títulos' %}</a>)</small>
+      </td>
+      <td>
+        {{ item.issue }}
+      </td>
+      <td>
+        {{ item.doi|default:"-" }}
+      </td>
+      <td>
+        {{ item.pid|default:"-" }}
+      </td>
+    </tr>
+   {% empty %}
+    <tr>
+      <td colspan="2">{% trans 'There are no items.' %}</td>
+    </tr>
+    {% endfor %}
+  <tbody>
+</table>

--- a/scielomanager/templates/include_press_release/issue.html
+++ b/scielomanager/templates/include_press_release/issue.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<table class="table table-striped _listings">
+  <thead>
+    <tr>
+      <th>{% trans 'Press Release' %}</th>
+      <th>{% trans 'Issue' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in objects_pr.object_list %}
+    <tr>
+      <td>
+          <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
+          <small>(<a href="#">{% trans 'Todos os títulos' %}</a>)</small>
+      </td>
+      <td>
+        {{ item.issue }}
+      </td>
+    </tr>
+   {% empty %}
+    <tr>
+      <td colspan="2">{% trans 'There are no items.' %}</td>
+    </tr>
+    {% endfor %}
+  <tbody>
+</table>


### PR DESCRIPTION
Este pull request é referente somente ao layout, a view que responde por esta página ainda não conhece os vários "tipos de press releases". Note que utilizei o mesmo recurso que temos na lista de Journals, tabs com links especializando as queries no banco.
