### PR TITLE
Tk418 - Refatoração da lista de Press Releases

### DIFF
--- a/scielomanager/journalmanager/assets.py
+++ b/scielomanager/journalmanager/assets.py
@@ -16,6 +16,7 @@ plugins_bundle = Bundle('../static/js/jquery/datepicker.js',
 app_bundle = Bundle('../static/js/bulk_actions.js',
                     '../static/js/languages.js',
                     '../static/js/multiselect.js',
+                    '../static/js/toggler.js',
                     '../static/js/tabslideout.js',
                     '../static/js/combobox.js',
                     '../static/js/bootstrap.js')

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -718,6 +718,13 @@ class Section(caching.base.CachingMixin, models.Model):
         return ' / '.join([sec_title.title for sec_title in self.titles.all().order_by('language')])
 
     @property
+    def get_titles(self):
+        """
+        Get all titles from Section
+        """
+        return [trans.title for trans in SectionTitle.objects.filter(section=self).order_by('language')]
+
+    @property
     def actual_code(self):
         if not self.pk or not self.code:
             raise AttributeError('section must be saved in order to have a code')

--- a/scielomanager/journalmanager/templates/journalmanager/pressrelease_dashboard.html
+++ b/scielomanager/journalmanager/templates/journalmanager/pressrelease_dashboard.html
@@ -56,22 +56,3 @@
 {% pagination objects_pr %}
 
 {% endblock %}
-
-{% block extrafooter %}
-{{ block.super }}
-
-<script>
-  function showTitles(div_id){
-
-    $('#' + div_id).toggle('slow', function(){
-      if($('#' + div_id).css('display') == 'none'){
-        $('#toggle_' + div_id).html("{% trans 'All Titles' %}");
-      }else{
-        $('#toggle_' + div_id).html("{% trans 'Hide Titles' %}");
-      }
-    });
-
-  }
-</script>
-
-{% endblock %}

--- a/scielomanager/journalmanager/templates/journalmanager/section_dashboard.html
+++ b/scielomanager/journalmanager/templates/journalmanager/section_dashboard.html
@@ -35,9 +35,18 @@
     {% for item in objects_section.object_list %}
     <tr>
       <td>
-        <h4>
+        <b>
           <a href="{% url section.edit item.journal.pk item.pk %}">{{ item }}</a>
-        </h4>
+        </b>
+        {% if item.get_titles|length > 1  %}
+          <div class="toggler" style="display: none;">
+            {% for title in item.get_titles %}
+              {% if not forloop.first %}
+                <a href="{% url section.edit item.journal.pk item.pk %}">{{ title }}</a></br>
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
       </td>
       <td>
         {{ item.actual_code }}

--- a/scielomanager/static/js/toggler.js
+++ b/scielomanager/static/js/toggler.js
@@ -1,0 +1,21 @@
+/*
+ * Get all div with class=toggler and apply show/hide
+ */
+
+$(document).ready(function() {
+
+  $('.toggler').each(function(){
+
+    var $show_hide_link = $('<a class="icon-chevron-down"></a>')
+          .attr("href", "javascript:void(0)")
+          .click(function() {
+            $(this).next().toggle('slow', function(){
+              $(this).prev().toggleClass('icon-chevron-down icon-chevron-up')
+            });
+          });
+
+    $(this).before($show_hide_link);
+
+  });
+
+});

--- a/scielomanager/templates/include_press_release/ahead.html
+++ b/scielomanager/templates/include_press_release/ahead.html
@@ -11,15 +11,14 @@
     <tr>
       <td>
           <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
-          {% if item.get_titles.count > 1 %}
-            <div id="{{item.pk}}" style="display: none;">
+          {% if item.get_titles|length > 1 %}
+            <div class="toggler" style="display: none;">
               {% for title in item.get_titles %}
                 {% if not forloop.first %}
                   <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
                 {% endif %}
               {% endfor %}
             </div>
-            <small>(<a href="#" id="toggle_{{item.pk}}" OnClick="showTitles({{item.pk}})">{% trans 'Todos os títulos' %}</a>)</small>
           {% endif %}
       </td>
       <td>

--- a/scielomanager/templates/include_press_release/article.html
+++ b/scielomanager/templates/include_press_release/article.html
@@ -15,15 +15,14 @@
             {{ item }}
           </a>
         </b>
-        {% if item.get_titles.count > 1 %}
-          <div id="{{item.pk}}" style="display: none;">
+        {% if item.get_titles|length > 1 %}
+          <div class="toggler" style="display: none;">
             {% for title in item.get_titles %}
               {% if not forloop.first %}
                 <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
               {% endif %}
             {% endfor %}
           </div>
-          <small>(<a href="#" id="toggle_{{item.pk}}" OnClick="showTitles({{item.pk}})">{% trans 'Todos os títulos' %}</a>)</small>
         {% endif %}
       </td>
       <td>

--- a/scielomanager/templates/include_press_release/issue.html
+++ b/scielomanager/templates/include_press_release/issue.html
@@ -11,15 +11,14 @@
     <tr>
       <td>
           <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
-          {% if item.get_titles.count > 1 %}
-            <div id="{{item.pk}}" style="display: none;">
+          {% if item.get_titles|length > 1  %}
+            <div class="toggler" style="display: none;">
               {% for title in item.get_titles %}
                 {% if not forloop.first %}
                   <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
                 {% endif %}
               {% endfor %}
             </div>
-            <small>(<a href="#" id="toggle_{{item.pk}}" OnClick="showTitles({{item.pk}})">{% trans 'Todos os títulos' %}</a>)</small>
           {% endif %}
       </td>
       <td>


### PR DESCRIPTION
Reparem que optei por utilizar um símbolo ou invés de um texto para o toggle a justificativa está na escolha por generalizar a funcionalidade de toggle. Encontrariamos dificultadades para tradução/alteração de textos.

Melhorias: 
1. Não existe referências entre o componente que será show/hide e o compomente de realiza essa função;
2. Com esse javascript toggle.js é possível reutilizar para qualquer div apenas colocando uma class="toggler".
