### PR TITLE
Ajustes na API Rest para a inclusão do endpoint ``apressreleases``

### DIFF
--- a/docs/dev/pressreleases-api.rst
+++ b/docs/dev/pressreleases-api.rst
@@ -1,5 +1,12 @@
 Press Releases API
-============
+==================
+
+..note::
+
+  There are two endpoints for querying press releases.
+  **pressreleases**, for regular press releases, and **apressreleases**
+  for articles published as ahead of print.
+
 
 List all press releases
 -----------------------

--- a/scielomanager/api/tests.py
+++ b/scielomanager/api/tests.py
@@ -706,3 +706,134 @@ class PressReleaseRestAPITest(WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('objects' in response.content)
         self.assertEqual(len(json.loads(response.content)['objects']), 1)
+
+
+class AheadPressReleaseRestAPITest(WebTest):
+
+    def setUp(self):
+        self.user = auth.UserF(is_active=True)
+        self.extra_environ = _make_auth_environ(self.user.username,
+            self.user.api_key.key)
+
+    def test_post_data(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.post('/api/v1/apressreleases/',
+            extra_environ=self.extra_environ, status=405)
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_put_data(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.put('/api/v1/apressreleases/',
+            extra_environ=self.extra_environ, status=405)
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_del_data(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.delete('/api/v1/apressreleases/',
+            extra_environ=self.extra_environ, status=405)
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_access_denied_for_unauthenticated_users(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.get('/api/v1/apressreleases/', status=401)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_pressrelease_index(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.get('/api/v1/apressreleases/',
+            extra_environ=self.extra_environ)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+
+    def test_api_v1_datamodel(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        response = self.app.get('/api/v1/apressreleases/%s/' % pr.pk,
+            extra_environ=self.extra_environ)
+
+        expected_keys = [
+            u'articles',
+            u'id',
+            u'journal_uri',
+            u'resource_uri',
+            u'translations',
+            u'doi',
+        ]
+
+        self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))
+
+    def test_translations_api_v1_datamodel(self):
+        pr = modelfactories.AheadPressReleaseFactory.create()
+        pr_trans = modelfactories.PressReleaseTranslationFactory.create(press_release=pr)
+        response = self.app.get('/api/v1/apressreleases/%s/' % pr_trans.press_release.pk,
+            extra_environ=self.extra_environ)
+
+        expected_keys = [
+            u'content',
+            u'id',
+            u'language',
+            u'resource_uri',
+            u'title',
+        ]
+
+        self.assertEqual(
+            sorted(response.json['translations'][0].keys()),
+            sorted(expected_keys)
+        )
+
+    def test_article_filter(self):
+        prelease = modelfactories.AheadPressReleaseFactory.create()
+        pr_articles = []
+        for pr in range(5):
+            pr_articles.append(modelfactories.PressReleaseArticleFactory.create(press_release=prelease))
+
+        response = self.app.get(
+            '/api/v1/apressreleases/?article_pid=%s' % pr_articles[0].article_pid,
+            extra_environ=self.extra_environ)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+        self.assertEqual(len(json.loads(response.content)['objects']), 1)
+
+    def test_journal_filter(self):
+        prs = []
+        for pr in range(5):
+            prs.append(modelfactories.AheadPressReleaseFactory.create())
+
+        response = self.app.get(
+            '/api/v1/apressreleases/?journal_pid=%s' % prs[0].journal.scielo_pid,
+            extra_environ=self.extra_environ)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+        self.assertEqual(len(json.loads(response.content)['objects']), 1)
+
+    def test_journal_filter_for_nonexisting_values_skips_filtering(self):
+        prs = []
+        for pr in range(5):
+            prs.append(modelfactories.AheadPressReleaseFactory.create())
+        response = self.app.get(
+            '/api/v1/apressreleases/?journal_pid=5',
+            extra_environ=self.extra_environ)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+        self.assertEqual(len(json.loads(response.content)['objects']), 0)
+
+    def test_article_filter_for_nonexisting_values_skips_filtering(self):
+        prelease = modelfactories.AheadPressReleaseFactory.create()
+        pr_articles = []
+        for pr in range(5):
+            pr_articles.append(modelfactories.PressReleaseArticleFactory.create(press_release=prelease))
+
+        response = self.app.get(
+            '/api/v1/apressreleases/?article_pid=EMPTY',
+            extra_environ=self.extra_environ)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+        self.assertEqual(len(json.loads(response.content)['objects']), 0)

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -234,6 +234,17 @@ class RegularPressReleaseCustomManager(caching.base.CachingManager):
         return preleases_qset.filter(issue__publication_year=year).filter(issue__order=order)
 
 
+class AheadPressReleaseCustomManager(caching.base.CachingManager):
+
+    def by_journal_pid(self, journal_pid):
+        """
+        Returns all PressReleases related to a Journal, given its
+        PID.
+        """
+        preleases = self.filter(models.Q(journal__print_issn=journal_pid) | models.Q(journal__eletronic_issn=journal_pid))
+        return preleases
+
+
 class Language(caching.base.CachingMixin, models.Model):
     """
     Represents ISO 639-1 Language Code and its language name in English. Django
@@ -1063,6 +1074,7 @@ class RegularPressRelease(PressRelease):
 
 
 class AheadPressRelease(PressRelease):
+    objects = AheadPressReleaseCustomManager()
     journal = models.ForeignKey(Journal, related_name='press_releases')
 
 ####

--- a/scielomanager/journalmanager/tests/modelfactories.py
+++ b/scielomanager/journalmanager/tests/modelfactories.py
@@ -164,6 +164,13 @@ class RegularPressReleaseFactory(factory.Factory):
     doi = factory.Sequence(lambda n: 'http://dx.doi.org/10.4415/ANN_12_01_%s' % n)
 
 
+class AheadPressReleaseFactory(factory.Factory):
+    FACTORY_FOR = models.AheadPressRelease
+
+    journal = factory.SubFactory(JournalFactory)
+    doi = factory.Sequence(lambda n: 'http://dx.doi.org/10.4415/ANN_12_01_%s' % n)
+
+
 class PressReleaseTranslationFactory(factory.Factory):
     FACTORY_FOR = models.PressReleaseTranslation
 

--- a/scielomanager/urls.py
+++ b/scielomanager/urls.py
@@ -22,6 +22,7 @@ v1_api_resources = [
     resources.SectionResource(),
     resources.DataChangeEventResource(),
     resources.PressReleaseResource(),
+    resources.AheadPressReleaseResource(),
 ]
 for res in v1_api_resources:
     v1_api.register(res)


### PR DESCRIPTION
A fim de manter a implementação simples, foi criado um segundo endpoint para representar registros de press releases relacionados a artigos publicados em ahead of print. Este endpoint disponibiliza as mesmas facilidades de busca, exceto o filtro issue_pid.
