### PR TITLE
Removido o método get_titles e contemplado a solução no template

### DIFF
--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -718,13 +718,6 @@ class Section(caching.base.CachingMixin, models.Model):
         return ' / '.join([sec_title.title for sec_title in self.titles.all().order_by('language')])
 
     @property
-    def get_titles(self):
-        """
-        Get all titles from Section
-        """
-        return [trans.title for trans in SectionTitle.objects.filter(section=self).order_by('language')]
-
-    @property
     def actual_code(self):
         if not self.pk or not self.code:
             raise AttributeError('section must be saved in order to have a code')
@@ -1029,13 +1022,6 @@ class PressRelease(caching.base.CachingMixin, models.Model):
             return _('No Title')
 
         return title
-
-    @property
-    def get_titles(self):
-        """
-        Get all titles from Press Release
-        """
-        return [trans.title for trans in PressReleaseTranslation.objects.filter(press_release=self).order_by('language')]
 
     class Meta:
         abstract = False

--- a/scielomanager/journalmanager/templates/journalmanager/section_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/section_list.html
@@ -31,11 +31,11 @@
         <b>
           <a href="{% url section.edit item.journal.pk item.pk %}">{{ item }}</a>
         </b>
-        {% if item.get_titles|length > 1  %}
+        {% if item.titles.all|length > 1  %}
           <div class="toggler" style="display: none;">
-            {% for title in item.get_titles %}
+            {% for trans in item.titles.all %}
               {% if not forloop.first %}
-                <a href="{% url section.edit item.journal.pk item.pk %}">{{ title }}</a></br>
+                <a href="{% url section.edit item.journal.pk item.pk %}">{{ trans.title }}</a></br>
               {% endif %}
             {% endfor %}
           </div>

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -647,23 +647,6 @@ class PressReleaseTests(TestCase):
 
         self.assertIsInstance(pr.get_trans('en'), PressReleaseTranslation)
 
-    def test_property_get_titles_must_return_list_of_titles(self):
-
-        issue = IssueFactory()
-        language = LanguageFactory.create(iso_code='en', name='english')
-        pr = RegularPressReleaseFactory.create(issue=issue)
-        pr.add_translation('Breaking news!',
-                           'This issue is awesome!',
-                            language)
-        pr.add_translation('I will nerver know the translation!',
-                           'Fantastic content!',
-                            language)
-
-        self.assertIsInstance(pr.get_titles, list)
-        self.assertEqual(pr.get_titles[0], 'Breaking news!')
-        self.assertEqual([title for title in pr.get_titles], ['Breaking news!',
-                        'I will nerver know the translation!'])
-
     def test_raises_DoesNotExist_if_unknown_iso_code_for_get_trans(self):
         from journalmanager.models import PressReleaseTranslation
 

--- a/scielomanager/templates/base_lv1.html
+++ b/scielomanager/templates/base_lv1.html
@@ -108,6 +108,34 @@
         </a>
       </li>
       {% endif %}
+      <li class="pull-right">
+        <form id="search-form" action="" method="get">
+          <select id="list_model" class="list-model" name="list_model">
+            {% if perms.journalmanager.list_journal %}
+              <option {% if 'journal' in request.path %}selected{% endif %}
+                      value="{% url journal.index %}">
+                {% trans 'Journals' %}
+              </option>
+            {% endif %}
+            {% if perms.journalmanager.list_sponsor %}
+              <option {% if 'sponsor' in request.path %}selected{% endif %}
+                      value="{% url sponsor.index %}">
+                {% trans 'Sponsors' %}
+              </option>
+            {% endif %}
+          </select>
+          <input class="input-search"
+             placeholder="Search"
+             name="q"
+             value="{{request.GET.q}}"/>
+          <button class="btn"
+              style="vertical-align: 4px;"
+              type="submit">
+          <i class="icon-search icon-black"></i>
+          {% trans 'Search' %}
+          </button>
+        </form>
+      </li>
     </ul>
   </div>
   <div class="span6">
@@ -124,34 +152,7 @@
         {% endif %}
       {% endblock %}
   </div>
-  <div class="nav pull-right">
-    <form id="search-form" action="" method="get">
-      <select id="list_model" class="list-model" name="list_model">
-        {% if perms.journalmanager.list_journal %}
-          <option {% if 'journal' in request.path %}selected{% endif %}
-                  value="{% url journal.index %}">
-            {% trans 'Journals' %}
-          </option>
-        {% endif %}
-        {% if perms.journalmanager.list_sponsor %}
-          <option {% if 'sponsor' in request.path %}selected{% endif %}
-                  value="{% url sponsor.index %}">
-            {% trans 'Sponsors' %}
-          </option>
-        {% endif %}
-      </select>
-      <input class="input-search"
-             placeholder="Search"
-             name="q"
-             value="{{request.GET.q}}"/>
-      <button class="btn"
-              style="vertical-align: 4px;"
-              type="submit">
-        <i class="icon-search icon-black"></i>
-        {% trans 'Search' %}
-      </button>
-    </form>
-  </div>
+
   <div class="row-fluid" style="min-height: 380px;">
     <div>
       {% block shortaccess %}{% endblock %}

--- a/scielomanager/templates/include_press_release/ahead.html
+++ b/scielomanager/templates/include_press_release/ahead.html
@@ -11,11 +11,11 @@
     <tr>
       <td>
           <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
-          {% if item.get_titles|length > 1 %}
+          {% if item.translations.all|length > 1 %}
             <div class="toggler" style="display: none;">
-              {% for title in item.get_titles %}
+              {% for trans in item.translations.all %}
                 {% if not forloop.first %}
-                  <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
+                  <a href="{% url prelease.edit journal.id item.pk %}">{{ trans.title }}</a></br>
                 {% endif %}
               {% endfor %}
             </div>

--- a/scielomanager/templates/include_press_release/article.html
+++ b/scielomanager/templates/include_press_release/article.html
@@ -15,11 +15,11 @@
             {{ item }}
           </a>
         </b>
-        {% if item.get_titles|length > 1 %}
+        {% if item.translations.all|length > 1 %}
           <div class="toggler" style="display: none;">
-            {% for title in item.get_titles %}
+            {% for trans in item.translations.all %}
               {% if not forloop.first %}
-                <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
+                <a href="{% url prelease.edit journal.id item.pk %}">{{ trans.title }}</a></br>
               {% endif %}
             {% endfor %}
           </div>

--- a/scielomanager/templates/include_press_release/issue.html
+++ b/scielomanager/templates/include_press_release/issue.html
@@ -11,11 +11,11 @@
     <tr>
       <td>
           <b><a href="{% url prelease.edit journal.id item.pk %}">{{ item }}</a></b>
-          {% if item.get_titles|length > 1  %}
+          {% if item.translations.all|length > 1  %}
             <div class="toggler" style="display: none;">
-              {% for title in item.get_titles %}
+              {% for trans in item.translations.all %}
                 {% if not forloop.first %}
-                  <a href="{% url prelease.edit journal.id item.pk %}">{{ title }}</a></br>
+                  <a href="{% url prelease.edit journal.id item.pk %}">{{ trans.title }}</a></br>
                 {% endif %}
               {% endfor %}
             </div>


### PR DESCRIPTION
Realizei a desenvolvimento no template mesmo, pois, se optarssimos por realizar isso na view-function teriamos que navegar entre os pressreleases para extrair os títulos (repare que a view pressrelease_index tem preleases que é uma lista de press releases), desta forma decidi navegar pelos títulos no template.

Também foi realizado o ajuste na lista de Seções.
