### PR TITLE
Resolvendo problema de apresentação de fascículos indisponíveis no formulário de criação de press-releases

### DIFF
--- a/scielomanager/journalmanager/forms.py
+++ b/scielomanager/journalmanager/forms.py
@@ -399,7 +399,7 @@ class RegularPressReleaseForm(ModelForm):
         if not self.journal:
             raise TypeError('missing journal argument')
 
-        self.fields['issue'].queryset = models.Issue.objects.filter(
+        self.fields['issue'].queryset = models.Issue.objects.available().filter(
             journal__pk=self.journal.pk)
 
     class Meta:


### PR DESCRIPTION
Esse ajuste evitará que fascículos de press-releases criados na versão sejam selecionado ao vincular um novo pressrelease a um fascículo.

Referente ao ticket #526
