### PR TITLE
Fixes #557 - Bug que impede que exista mais de 1 suplemento de volume num mesmo ano de publicação

### DIFF
--- a/scielomanager/journalmanager/forms.py
+++ b/scielomanager/journalmanager/forms.py
@@ -291,11 +291,15 @@ class IssueForm(ModelForm):
     def clean(self):
         volume = self.cleaned_data.get('volume')
         number = self.cleaned_data.get('number')
+        suppl_volume = self.cleaned_data.get('suppl_volume')
+        suppl_number = self.cleaned_data.get('suppl_number')
         publication_year = self.cleaned_data.get('publication_year')
 
         if volume or number:
             issue = models.Issue.objects.filter(number=number,
                                                 volume=volume,
+                                                suppl_volume=suppl_volume,
+                                                suppl_number=suppl_number,
                                                 publication_year=publication_year,
                                                 journal=self.journal_id)
 


### PR DESCRIPTION
O método `forms.IssueForm.clean` considerava os valores de _number_ e _volume_ para saber se o fascículo sendo cadastrado já existe. Os valores dos suplementos foram adicionados nessa equação.
