### PR TITLE
Ajustes no manager RegularPressReleaseCustomManager.by_journal_pid para realizar uma query mais eficiente ao BD

### DIFF
--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -200,16 +200,10 @@ class RegularPressReleaseCustomManager(caching.base.CachingManager):
         Returns all PressReleases related to a Journal, given its
         PID.
         """
-        try:
-            journal = Journal.objects.get(
-                models.Q(print_issn=journal_pid) | models.Q(eletronic_issn=journal_pid))
-            issues_pks = [iss.pk for iss in journal.issue_set.all()]
-        except Journal.DoesNotExist:
-            # little hack to act as .filter, returning an empty
-            # queryset bound to the model.
-            issues_pks = [None]
+        journals = Journal.objects.filter(
+            models.Q(print_issn=journal_pid) | models.Q(eletronic_issn=journal_pid))
 
-        preleases = self.filter(issue__pk__in=issues_pks)
+        preleases = self.filter(issue__journal__in=journals.values('id')).select_related('translations')
         return preleases
 
     def all_by_journal(self, journal):


### PR DESCRIPTION
A query resultante deste ticket ficou assim:

``` sql
SELECT "journalmanager_pressrelease"."id", 
       "journalmanager_pressrelease"."doi", 
       "journalmanager_regularpressrelease"."pressrelease_ptr_id", 
       "journalmanager_regularpressrelease"."issue_id" 
FROM "journalmanager_regularpressrelease" 
    INNER JOIN "journalmanager_pressrelease" 
    ON ("journalmanager_regularpressrelease"."pressrelease_ptr_id" = "journalmanager_pressrelease"."id") 
    WHERE "journalmanager_regularpressrelease"."pressrelease_ptr_id" IN (
        SELECT U0."pressrelease_ptr_id" 
        FROM "journalmanager_regularpressrelease" U0 
        INNER JOIN "journalmanager_issue" U1 
        ON (U0."issue_id" = U1."id") 
        WHERE U1."journal_id" IN (
            SELECT U0."id" 
            FROM "journalmanager_journal" U0 
            WHERE (U0."print_issn" = '0034-8910'  OR U0."eletronic_issn" = '0034-8910' ))) 
LIMIT 20;

```

O uso de subqueries e pré-carga das traduções fez com que o endpoint _pressreleases_ melhorasse o desempenho em aproximadamente 50%, de acordo com medição tosca.
