### PR TITLE
Resolução do conflito de related_name e política de acesso

### DIFF
--- a/scielomanager/articletrack/models.py
+++ b/scielomanager/articletrack/models.py
@@ -53,7 +53,7 @@ class Article(caching.base.CachingMixin, models.Model):
     objects = models.Manager()
     userobjects = modelmanagers.ArticleManager()
 
-    journals = models.ManyToManyField(Journal, null=True, related_name='articles')
+    journals = models.ManyToManyField(Journal, null=True, related_name='checkin_articles')
     article_title = models.CharField(max_length=512)
     articlepkg_ref = models.CharField(max_length=32)
     journal_title = models.CharField(max_length=256)

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -859,6 +859,10 @@ class Issue(caching.base.CachingMixin, models.Model):
 
     order = models.IntegerField(_('Issue Order'), blank=True)
 
+    class Meta:
+        permissions = (("list_issue", "Can list Issues"),
+                      ("reorder_issue", "Can Reorder Issues"))
+
     @property
     def scielo_pid(self):
         """
@@ -934,10 +938,6 @@ class Issue(caching.base.CachingMixin, models.Model):
                 self.order = self._suggest_order(force=True)
 
         super(Issue, self).save(*args, **kwargs)
-
-    class Meta:
-        permissions = (("list_issue", "Can list Issues"),
-                      ("reorder_issue", "Can Reorder Issues"))
 
 
 class IssueTitle(caching.base.CachingMixin, models.Model):
@@ -1102,11 +1102,14 @@ class Article(caching.base.CachingMixin, models.Model):
     objects = caching.base.CachingManager()
     nocacheobjects = models.Manager()
 
-    issue = models.ForeignKey(Issue, related_name='issue_article')
+    issue = models.ForeignKey(Issue, related_name='articles')
     front = jsonfield.JSONField()
     xml_url = models.CharField(_('XML URL'), max_length=256)
     pdf_url = models.CharField(_('PDF URL'), max_length=256)
     images_url = models.CharField(_('Images URL'), max_length=256)
+
+    class Meta:
+        permissions = (("list_article", "Can list Article"),)
 
     @property
     def title(self):

--- a/scielomanager/journalmanager/tests/tests_pages.py
+++ b/scielomanager/journalmanager/tests/tests_pages.py
@@ -26,40 +26,36 @@ class ArticleTests(WebTest):
         self.collection.add_user(self.user, is_manager=True)
 
     def test_list_without_articles(self):
+        perm_article_list = _makePermission(perm='list_article',
+                                            model='article',
+                                            app_label='journalmanager')
+        self.user.user_permissions.add(perm_article_list)
 
         journal = modelfactories.JournalFactory(collection=self.collection)
         issue = modelfactories.IssueFactory(journal=journal)
-        perm_journal_list = _makePermission(perm='list_pressrelease',
-                                            model='pressrelease',
-                                            app_label='journalmanager')
 
-        self.user.user_permissions.add(perm_journal_list)
-
-        response = self.app.get(reverse('article.index', args=[issue.pk]))
+        response = self.app.get(reverse('article.index', args=[issue.pk]), user=self.user)
 
         self.assertTrue('There are no items.' in response.body)
 
     def test_list_with_articles(self):
+        perm_article_list = _makePermission(perm='list_article',
+                                            model='article',
+                                            app_label='journalmanager')
+        self.user.user_permissions.add(perm_article_list)
 
         journal = modelfactories.JournalFactory(collection=self.collection)
         issue = modelfactories.IssueFactory(journal=journal)
-        perm_journal_list = _makePermission(perm='list_pressrelease',
-                                            model='pressrelease',
-                                            app_label='journalmanager')
 
         front = {
             'title-group': {
-                'en': 'Article Title 1',
-                'pt': 'Título do Artigo 1'
+                'en': u'Article Title 1',
+                'pt': u'Título do Artigo 1'
             }
         }
 
         article = modelfactories.ArticleFactory.create(issue=issue, front=front)
-        article.save()
-
-        self.user.user_permissions.add(perm_journal_list)
-
-        response = self.app.get(reverse('article.index', args=[issue.pk]))
+        response = self.app.get(reverse('article.index', args=[issue.pk]), user=self.user)
 
         self.assertTrue('Article Title 1' in response.body)
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -130,6 +130,7 @@ def list_search(request, model, journal_id):
         context_instance=RequestContext(request))
 
 
+@permission_required('journalmanager.list_article', login_url=AUTHZ_REDIRECT_URL)
 def article_index(request, issue_id):
 
     issue = get_object_or_404(models.Issue, pk=issue_id)
@@ -139,7 +140,7 @@ def article_index(request, issue_id):
         {
             'journal': issue.journal,
             'issue': issue,
-            'articles': issue.issue_article.all()
+            'articles': issue.articles.all()
         },
         context_instance=RequestContext(request)
     )


### PR DESCRIPTION
Fixes #615 and Fixes #608. 

Resolução do conflito de related_name de _articletrack.models.Article.journal_ e política de acesso na view-function que lista os artigos.
