### PR TITLE
Modelmanagers agora é um pacote em nível de projeto

### DIFF
--- a/scielomanager/api/tests.py
+++ b/scielomanager/api/tests.py
@@ -24,7 +24,7 @@ from api.resources import (
     CommentResource,
     )
 
-from journalmanager.tests.helpers import (
+from scielomanager.utils.modelmanagers.helpers import (
     _makeUserRequestContext,
     _patch_userrequestcontextfinder_settings_setup,
     _patch_userrequestcontextfinder_settings_teardown
@@ -1073,7 +1073,7 @@ class NoticeRestAPITest(WebTest):
 
 
 class CheckinArticleRestAPITest(WebTest):
-    
+
     @_patch_userrequestcontextfinder_settings_setup
     def setUp(self):
         self.user = auth.UserF(is_active=True)
@@ -1162,10 +1162,10 @@ class CheckinArticleRestAPITest(WebTest):
         ]
 
         self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))
-        
+
 
 class TicketRestAPITest(WebTest):
-    
+
     @_patch_userrequestcontextfinder_settings_setup
     def setUp(self):
         self.user = auth.UserF(is_active=True)
@@ -1179,7 +1179,7 @@ class TicketRestAPITest(WebTest):
         pass
 
     def test_post_data(self):
-        
+
         perm = _makePermission(perm='add_ticket', model='ticket', app_label='articletrack')
         self.user.user_permissions.add(perm)
 
@@ -1209,7 +1209,7 @@ class TicketRestAPITest(WebTest):
 
         att = {u'finished_at': '2013-11-18 15:23:12',}
         ticket = articletrack_modelfactories.TicketFactory.create(author=self.author, article=self.article)
-        
+
         response = self.app.put_json('/api/v1/tickets/%s/' % ticket.pk,
 	                                att,
 	                                extra_environ=self.extra_environ,
@@ -1260,7 +1260,7 @@ class TicketRestAPITest(WebTest):
 
 
 class CommentRestAPITest(WebTest):
-    
+
     @_patch_userrequestcontextfinder_settings_setup
     def setUp(self):
         self.user = auth.UserF(is_active=True)
@@ -1274,7 +1274,7 @@ class CommentRestAPITest(WebTest):
         pass
 
     def test_post_data(self):
-        
+
         perm = _makePermission(perm='add_comment', model='comment', app_label='articletrack')
         self.user.user_permissions.add(perm)
 
@@ -1283,7 +1283,7 @@ class CommentRestAPITest(WebTest):
             u'message': u'message of the comment',
             u'ticket': u'/api/v1/tickets/%s/' % self.ticket.pk,
         }
-        
+
         response = self.app.post_json('/api/v1/comments/',
                                       att,
                                       extra_environ=self.extra_environ,

--- a/scielomanager/articletrack/modelmanagers.py
+++ b/scielomanager/articletrack/modelmanagers.py
@@ -1,5 +1,9 @@
 #coding: utf-8
-from journalmanager.modelmanagers import UserObjectQuerySet, UserObjectManager, user_request_context
+from scielomanager.utils import usercontext
+from scielomanager.utils.modelmanagers import UserObjectQuerySet, UserObjectManager
+
+user_request_context = usercontext.get_finder()
+
 
 # CHECKIN
 
@@ -68,3 +72,4 @@ class CommentQuerySet(UserObjectQuerySet):
 class CommentManager(UserObjectManager):
     def get_query_set(self):
         return CommentQuerySet(self.model, using=self._db)
+

--- a/scielomanager/articletrack/tests/tests_pages.py
+++ b/scielomanager/articletrack/tests/tests_pages.py
@@ -3,12 +3,14 @@ from waffle import Flag
 from django_webtest import WebTest
 from django_factory_boy import auth
 from django.core.urlresolvers import reverse
+
 from . import modelfactories
-from journalmanager.tests.helpers import (
+from scielomanager.utils.modelmanagers.helpers import (
     _makeUserRequestContext,
     _patch_userrequestcontextfinder_settings_setup,
     _patch_userrequestcontextfinder_settings_teardown
     )
+
 
 def _makePermission(perm, model, app_label='articletrack'):
     """

--- a/scielomanager/journalmanager/modelmanagers.py
+++ b/scielomanager/journalmanager/modelmanagers.py
@@ -32,32 +32,9 @@ Custom instance of ``models.query.QuerySet``
 import caching.base
 
 from scielomanager.utils import usercontext
+from scielomanager.utils.modelmanagers import UserObjectQuerySet, UserObjectManager
 
 user_request_context = usercontext.get_finder()
-
-
-class UserObjectQuerySet(caching.base.CachingQuerySet):
-    """
-    Provides a basic implementation of userobject querysets with
-    caching features.
-    """
-    def available(self):
-        return self
-
-    def unavailable(self):
-        return self.none()
-
-
-class UserObjectManager(caching.base.CachingManager):
-    """
-    Provides a basic implementation of userobject managers with
-    caching features.
-    """
-    def all(self, **kwargs):
-        return self.get_query_set().all(**kwargs)
-
-    def active(self, **kwargs):
-        return self.get_query_set().active(**kwargs)
 
 
 class JournalQuerySet(UserObjectQuerySet):
@@ -183,3 +160,4 @@ class AheadPressReleaseQuerySet(UserObjectQuerySet):
 class AheadPressReleaseManager(UserObjectManager):
     def get_query_set(self):
         return AheadPressReleaseQuerySet(self.model, using=self._db)
+

--- a/scielomanager/journalmanager/tests/tests_pages.py
+++ b/scielomanager/journalmanager/tests/tests_pages.py
@@ -10,7 +10,7 @@ from django_factory_boy import auth
 
 from journalmanager.tests import modelfactories
 from journalmanager.tests.tests_forms import _makePermission
-from helpers import (
+from scielomanager.utils.modelmanagers.helpers import (
     _makeUserRequestContext,
     _patch_userrequestcontextfinder_settings_setup,
     _patch_userrequestcontextfinder_settings_teardown

--- a/scielomanager/scielomanager/utils/modelmanagers/__init__.py
+++ b/scielomanager/scielomanager/utils/modelmanagers/__init__.py
@@ -1,0 +1,2 @@
+from .base import UserObjectQuerySet, UserObjectManager
+

--- a/scielomanager/scielomanager/utils/modelmanagers/base.py
+++ b/scielomanager/scielomanager/utils/modelmanagers/base.py
@@ -1,0 +1,57 @@
+# coding: utf-8
+"""
+The UserObjectManager interface
+===============================
+
+Each model object that aims to be contextualized by the current
+app user and the visibility rules defined, must provide a
+manager called ``userobjects`` following the context protocol:
+
+Custom instance of ``models.Manager``
+-------------------------------------
+
+* ``get_query_set`` returns a custom subclass of models.query.QuerySet;
+* ``all`` returns all objects the user can access;
+* ``active`` returns a subset of ``all``, only with objects from
+  the active collection.
+
+Custom instance of ``models.query.QuerySet``
+--------------------------------------------
+
+* ``all`` returns all objects the user can access;
+* ``active`` returns all objects from the active collection.
+* ``startswith`` (optional) returns all objects with the given
+  initial char in a meaningful field. this is used for sorting
+  and presentation purposes.
+* ``simple_search`` (optional) performs a simple search query on one or more
+  meaningful fields. accepts only 1 string as search the search term.
+* ``available`` returns all objects not marked as trash.
+* ``unavailable`` returns all objects marked as trash.
+
+"""
+import caching.base
+
+
+class UserObjectQuerySet(caching.base.CachingQuerySet):
+    """
+    Provides a basic implementation of userobject querysets with
+    caching features.
+    """
+    def available(self):
+        return self
+
+    def unavailable(self):
+        return self.none()
+
+
+class UserObjectManager(caching.base.CachingManager):
+    """
+    Provides a basic implementation of userobject managers with
+    caching features.
+    """
+    def all(self, **kwargs):
+        return self.get_query_set().all(**kwargs)
+
+    def active(self, **kwargs):
+        return self.get_query_set().active(**kwargs)
+

--- a/scielomanager/scielomanager/utils/modelmanagers/helpers.py
+++ b/scielomanager/scielomanager/utils/modelmanagers/helpers.py
@@ -53,10 +53,11 @@ def _patch_userrequestcontextfinder_settings_teardown(func):
     """
     def wrapper(self, **kwargs):
         func(self, **kwargs)
-        
+
         attr_name = settings.USERREQUESTCONTEXT_FINDER.rsplit('.', 1)[-1]
         delattr(finders, attr_name)
 
         settings.USERREQUESTCONTEXT_FINDER = self.default_USERREQUESTCONTEXT_FINDER
 
     return wrapper
+


### PR DESCRIPTION
O código comum aos modelmanagers foi movido para _scielomanager.utils.modelmanagers.base_. Os helpers de testes automatizados para _scielomanager.utils.modelmanagers.helpers_. 

Fixes #610 
