### PR TITLE
Referenciar tickets usando hashtag nos textos e titulos #643

### DIFF
--- a/scielomanager/articletrack/templates/articletrack/comment_edit.html
+++ b/scielomanager/articletrack/templates/articletrack/comment_edit.html
@@ -10,6 +10,7 @@
     <div class="span10 offset1">
       <form action='.' method='POST'>
         {% include "articletrack/includes/form_snippet.html" %}
+        {% include "articletrack/includes/help_text_ticket_link.html" %}
       </form>
     </div>
   </div>

--- a/scielomanager/articletrack/templates/articletrack/includes/help_text_ticket_link.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/help_text_ticket_link.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+<span class="help-block">
+  {% blocktrans %}
+      <i class="icon-question-sign"></i> <strong>Pro tip:</strong> Is possible to add a link to another ticket, just write # followed by the ticket number (i.e.: #1234)
+  {% endblocktrans %}
+</span>

--- a/scielomanager/articletrack/templates/articletrack/includes/tickets_list_simple.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/tickets_list_simple.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load urlize_ticket %}
 
 {% if tickets|length > 0 %}
   <table class="table table-condensed table-hover">
@@ -18,7 +19,7 @@
             <img style="vertical-align:top;" src="{{ ticket.author.get_profile.avatar_url }}" alt="Gravatar">
             {{ ticket.author.get_full_name }}
           </td>
-          <td>{{ ticket.title }}</td>
+          <td>{{ ticket.title|capfirst|urlize_ticket_link }}</td>
           <td>
             <a href="{% url ticket_detail ticket.id %}" class="btn btn-mini btn" type="button">{% trans "Details" %}</a>
           </td>

--- a/scielomanager/articletrack/templates/articletrack/ticket_add.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_add.html
@@ -28,6 +28,7 @@
     <div class="span10 offset1">
       <form action='.' method='POST'>
         {% include "articletrack/includes/form_snippet.html" %}
+        {% include "articletrack/includes/help_text_ticket_link.html" %}
       </form>
     </div>
   </div>

--- a/scielomanager/articletrack/templates/articletrack/ticket_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_detail.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load urlize_ticket %}
 
 {% block page_title %}{% trans "Ticket detail" %}{% endblock %}
 
@@ -12,7 +13,7 @@
     {% else %}
       <span class="label label-important">{% trans "Closed" %}</span> 
     {% endif %}
-    {{ ticket.title|title }} <small>#{{ ticket.pk }}</small>
+    {{ ticket.title|capfirst|urlize_ticket_link }} <small>#{{ ticket.pk }}</small>
   </h1>
   <p class='muted'>
     <img style="vertical-align:top;" src="{{ ticket.author.get_profile.avatar_url }}" alt="Gravatar">
@@ -33,7 +34,7 @@
 <div class="row-fluid show-grid">
   <div class="span12">
     <h4>{% trans "Message" %}:</h4>
-    <blockquote>{{ ticket.message|linebreaksbr }}<blockquote>
+    <blockquote>{{ ticket.message|urlize_ticket_link|linebreaksbr  }}<blockquote>
   </div>
 
   {% if ticket.is_open %}
@@ -81,7 +82,7 @@
   <div class="row-fluid show-grid">
       <div class="span12">
           <blockquote>
-              {{ comment.message|linebreaksbr }}
+              {{ comment.message|urlize_ticket_link|linebreaksbr }}
               <small>
                   <img style="vertical-align:top;" src="{{ comment.author.get_profile.avatar_url }}" alt="Gravatar">
                   {{ comment.author.get_full_name }} <i class="icon-time"></i> 

--- a/scielomanager/articletrack/templates/articletrack/ticket_edit.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_edit.html
@@ -20,6 +20,7 @@
     <div class="span10 offset1">
       <form action='.' method='POST'>
         {% include "articletrack/includes/form_snippet.html" %}
+        {% include "articletrack/includes/help_text_ticket_link.html" %}
       </form>
     </div>
   </div>

--- a/scielomanager/articletrack/templatetags/urlize_ticket.py
+++ b/scielomanager/articletrack/templatetags/urlize_ticket.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import re
+from django.utils.safestring import mark_safe
+from django import template
+from django.core.urlresolvers import reverse
+
+register = template.Library()
+
+def urlize_ticket_link(text):
+    url_pattern = reverse('ticket_detail', args=['0'])
+    output = re.sub(r'#(\d+)',
+                  r'<a href="%s\1/">#\1</a>' % url_pattern.replace('/0', ''),
+                  text)
+    return mark_safe(output)
+
+register.filter('urlize_ticket_link', urlize_ticket_link)


### PR DESCRIPTION
Criado o filter, e utilizado no template do detalhe dos ticket.
Tambem tem un include para o texto de ajuda para o usuário.
