### PR TITLE
Reavaliarmos a navegação da aplicação ``articletrack`` #613

### DIFF
--- a/scielomanager/articletrack/templates/articletrack/checkin_list.html
+++ b/scielomanager/articletrack/templates/articletrack/checkin_list.html
@@ -32,7 +32,7 @@
       {% with article.grouper  as article_obj %}
         <tr id="primary_row_{{ forloop.counter}}" class="primary_row">
           <td>
-            <a href="#" class="btn show_checkins" data-target-row="{{ forloop.counter }}">
+            <a href="#" class="btn btn-mini show_checkins" data-target-row="{{ forloop.counter }}">
               <i id='indicator_{{ forloop.counter }}' class="icon-plus"></i>
             </a>
           </td>

--- a/scielomanager/articletrack/templates/articletrack/includes/tickets_list_simple.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/tickets_list_simple.html
@@ -1,37 +1,40 @@
 {% load i18n %}
 {% load urlize_ticket %}
+{% load user_avatar %}
 
-{% if tickets|length > 0 %}
-  <table class="table table-condensed table-hover">
-    <thead>
+<table class="table table-condensed table-hover">
+  <thead>
+    <tr>
+      <th class='span2'>{% trans "Author" %}:</th>
+      <th>{% trans "Title" %}:</th>
+      <th class='span2'></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for ticket in tickets %}
       <tr>
-        <th class='span2'>{% trans "Author" %}:</th>
-        <th>{% trans "Title" %}:</th>
-        <th class='span2'></th>
+        <td>
+          <img class="img-rounded" src="{% user_avatar_url ticket.author 'small' %}" alt="Gravatar">
+          {{ ticket.author.get_full_name }}
+        </td>
+        <td>{{ ticket.title|capfirst|urlize_ticket_link }}</td>
+        <td>
+          {% if ticket.is_open %}
+            <a href="#" class="close_ticket btn btn-mini btn-warning" type="button" data-ticket-id='{{ ticket.pk }}'>
+              <i class="icon-remove-circle"></i> {% trans "Close" %}
+            </a>
+          {% endif %}
+          <a href="{% url ticket_detail ticket.id %}" class="btn btn-mini btn pull-right" type="button">{% trans "Details" %}</a>
+        </td>
       </tr>
-    </thead>
-    <tbody>
-      {% for ticket in tickets %}
-        <tr>
-          <td>
-            <img style="vertical-align:top;" src="{{ ticket.author.get_profile.avatar_url }}" alt="Gravatar">
-            {{ ticket.author.get_full_name }}
-          </td>
-          <td>{{ ticket.title|capfirst|urlize_ticket_link }}</td>
-          <td>
-            {% if ticket.is_open %}
-              <a href="#" class="close_ticket btn btn-mini btn-warning" type="button" data-ticket-id='{{ ticket.pk }}'>
-                <i class="icon-remove-circle"></i> {% trans "Close" %}
-              </a>
-            {% endif %}
-            <a href="{% url ticket_detail ticket.id %}" class="btn btn-mini btn pull-right" type="button">{% trans "Details" %}</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% else %}
-  <div class="alert">
-    <strong>{% trans "No tickets" %}</strong>
-  </div>
-{% endif %}
+    {% empty %}
+      <tr>
+        <td colspan='3'>
+          <div class="alert alert-info">
+            <i class="icon-info-sign"></i> {% trans "No tickets" %}
+          </div>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/scielomanager/articletrack/templates/articletrack/notice_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/notice_detail.html
@@ -106,7 +106,11 @@
     </tr>
     {% empty %}
     <tr>
-      <td colspan="5">{% trans 'There are no items.' %}</td>
+      <td colspan="5">
+        <div class="alert alert-info">
+          <i class="icon-info-sign"></i> {% trans "There are no notices." %}
+        </div>
+      </td>
     </tr>
     {% endfor %}
   <tbody>

--- a/scielomanager/articletrack/templates/articletrack/ticket_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_detail.html
@@ -1,118 +1,149 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
 {% load urlize_ticket %}
+{% load user_avatar %}
 
 {% block page_title %}{% trans "Ticket detail" %}{% endblock %}
 
 {% block content %}
 
-<div class="page-header">
-  <h1>
-    {% if ticket.is_open %}
-      <span class="label label-success">{% trans "Open" %}</span> 
-    {% else %}
-      <span class="label label-important">{% trans "Closed" %}</span> 
-    {% endif %}
-    {{ ticket.title|capfirst|urlize_ticket_link }} <small>#{{ ticket.pk }}</small>
-  </h1>
-  <p class='muted'>
-    <img style="vertical-align:top;" src="{{ ticket.author.get_profile.avatar_url }}" alt="Gravatar">
-    {{ ticket.author.get_full_name }} 
-    {% trans "created this ticket on" %}: {{ ticket.started_at|date:"d/m/Y - H:i" }} &bull;
-    ({{ ticket.comments.all|length }} {% trans "comments" %})
-  </p>
-  {% if not ticket.is_open %}
-    <div class="alert alert-info">
-      <strong>
-        <i class="icon-ban-circle"></i> {% trans "The ticket was closed on" %}:
-      </strong>
-      {{ ticket.started_at|date:"d/m/Y - H:i" }}
+  <!-- NAVIGATIONS -->
+  <div class="navbar">
+    <div class="navbar-inner">
+      <ul class="nav">
+        <li>
+          <a href="{% url checkin_index %}"><i class="icon-chevron-left"></i> {% trans "List of Articles in submission" %}</a>
+        </li>
+        <li class="divider-vertical"></li>
+        <li class="active">
+          <a href="#">{% trans "Ticket" %}: #{{ ticket.pk }}</a>
+        </li>
+      </ul>
+      <ul class="nav pull-right">
+        <li class="divider-vertical"></li>
+        <li><a href="#comments" role="menuitem"><i class="icon-comment"></i> {% trans "Comments" %}</a></li>
+      </ul>
     </div>
-  {% endif %}
-</div>
+  </div>
 
-<div class="row-fluid show-grid">
-  <div class="span12">
-    <h4>{% trans "Message" %}:</h4>
-    <blockquote>{{ ticket.message|urlize_ticket_link|linebreaksbr  }}<blockquote>
+  <div class="page-header">
+    <h1>
+      {% if ticket.is_open %}
+        <span class="label label-success">{% trans "Open" %}</span> 
+      {% else %}
+        <span class="label label-important">{% trans "Closed" %}</span> 
+      {% endif %}
+      {{ ticket.title|capfirst|urlize_ticket_link }} <small>#{{ ticket.pk }}</small>
+    </h1>
+    {% if not ticket.is_open %}
+      <div class="alert alert-info">
+        <strong>
+          <i class="icon-ban-circle"></i> {% trans "The ticket was closed on" %}:
+        </strong>
+        <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ ticket.finished_at }}'>{{ ticket.finished_at|timesince }} {% trans "ago" %}</a>
+      </div>
+    {% endif %}
+  </div>
+
+  <div class="row-fluid show-grid">
+    <div class="span12">
+      <p class='muted'>
+        <img  class="img-rounded" src="{% user_avatar_url ticket.author 'medium' %}" alt="Gravatar">
+        {{ ticket.author.get_full_name }} 
+        {% trans "created this ticket on" %}:
+        <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ ticket.started_at }}'>{{ ticket.started_at|timesince }} {% trans "ago" %}</a>
+        <span class='pull-right'>
+          {{ ticket.comments.all|length }} {% trans "comments" %}
+        </span>
+      </p>
+      <div class='message_top_arror_box'>
+        {{ ticket.message|urlize_ticket_link|linebreaksbr }}
+      </div>
+    </div>
+
+    {% if ticket.is_open %}
+    
+      <div id='action_buttons_row'>
+        
+        {% if perms.comment.can_add or perms.ticket.can_add %}
+          <a id='add_comment' href="#" class="btn btn-success" type="button">
+            <i class="icon-plus-sign"></i> {% trans "Add Comment" %}
+          </a>
+        {% endif %}
+        
+        {% if perms.ticket.can_change %}
+
+          <a href="{% url ticket_edit ticket.pk %}" class='btn btn-primary'>
+            <i class="icon-pencil"></i> {% trans "Edit" %}
+          </a>
+
+          <a id='close_ticket' href="#" class="btn btn-warning pull-right" type="button">
+            <i class="icon-remove-circle"></i> {% trans "Close" %}
+          </a>
+
+        {% endif %}
+      </div>
+
+    {% endif %}
+
   </div>
 
   {% if ticket.is_open %}
-  
-    <div id='action_buttons_row'>
-      {% if perms.comment.can_add or perms.ticket.can_add %}
-        <a id='add_comment' href="#" class="btn btn-success" type="button">
-          <i class="icon-plus-sign"></i> {% trans "Add Comment" %}
-        </a>
-      {% endif %}
-      
-      {% if perms.ticket.can_change %}
-
-        <a href="{% url ticket_edit ticket.pk %}" class='btn'>
-          <i class="icon-pencil"></i> {% trans "Edit" %}
-        </a>
-
-        <a id='close_ticket' href="#" class="btn btn-warning pull-right" type="button">
-          <i class="icon-remove-circle"></i> {% trans "Close" %}
-        </a>
-
-      {% endif %}
+    <!-- ADD COMMENT FORM -->
+    <div id='add_comment_section_row' class='row hide_row'>
+      <div class="span10 offset1">
+        <form id='add_comment_form' action='.' method='POST'>
+          {% csrf_token %}
+          <div id='form_error_msg' class="alert alert-error" style='display:none;'></div>
+          {{ form }}
+          <input type='button' id='discard_comment' class='btn btn-danger pull-left' value='{% trans "Discard" %}'/>
+          <input type='submit' class='btn btn-primary pull-right' value='{% trans "Save" %}'/>
+        </form>
+      </div>
     </div>
-
   {% endif %}
 
-</div>
-{% if ticket.is_open %}
-  <!-- ADD COMMENT FORM -->
-  <div id='add_comment_section_row' class='row hide_row'>
-    <div class="span10 offset1">
-      <form id='add_comment_form' action='.' method='POST'>
-        {% csrf_token %}
-        <div id='form_error_msg' class="alert alert-error" style='display:none;'></div>
-        {{ form }}
-        <input type='button' id='discard_comment' class='btn btn-danger pull-left' value='{% trans "Discard" %}'/>
-        <input type='submit' class='btn btn-primary pull-right' value='{% trans "Send" %}'/>
-      </form>
-    </div>
-  </div>
-{% endif %}
-<!-- COMMENTS -->
-<h4>{% trans "Comments" %}:</h4>
-{% for comment in ticket.comments.all %}
-  <div class="row-fluid show-grid">
-      <div class="span12">
-          <blockquote>
-              {{ comment.message|urlize_ticket_link|linebreaksbr }}
-              <small>
-                  <img style="vertical-align:top;" src="{{ comment.author.get_profile.avatar_url }}" alt="Gravatar">
-                  {{ comment.author.get_full_name }} <i class="icon-time"></i> 
-                  <cite title="">
-                    {{ comment.created_at|date:"d/m/Y - H:i" }}
-                    {% if comment.created_at|date:"d/m/Y - H:i" != comment.updated_at|date:"d/m/Y - H:i" %}
-                      <em>({% trans "Updated" %}: {{ comment.updated_at|date:"d/m/Y - H:i" }} )</em>
-                    {% endif %}
-                    {% if request.user == comment.author and comment.ticket.is_open %}
-                      <i class="icon-edit"></i> <a href="{% url comment_edit comment.pk %}">{% trans "Edit" %}</a>
-                    {% endif %}
-                  </cite>
-              </small>
-          </blockquote>
-          <hr>
-      </div>
-  </div>
-{% empty %}
-  <p>{% trans "No comments" %}</p>
-{% endfor %}
+  <!-- COMMENTS -->
+  <a name="comments"></a><br><br>
+  <h4>{% trans "Comments" %}:</h4>
 
-<!-- NAVIGATIONS -->
-<div class="row-fluid show-grid">
-  <div class="span12">
-    <div class="btn-group">
-      <a class="btn disabled">{% trans 'Go to' %}:</a>
-      <a class="btn" href="{% url checkin_index %}"><i class="icon-arrow-left"></i> {% trans "List of Articles in submission" %}</a>
+  {% for comment in ticket.comments.all %}
+
+    <div class="row-fluid show-grid">
+      <div class="span1">
+        <img class="img-rounded" src="{% user_avatar_url comment.author 'medium' %}" alt="Gravatar">
+        <br>
+        <small>{{ comment.author.get_full_name }}</small>
+      </div>
+      <div class="span11">
+        <div class='comment_left_arrow_box'>
+          <small>
+            {% trans "Commented" %}: 
+            <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.created_at }}'>{{ comment.created_at|timesince }} {% trans "ago" %}</a>
+            {% if comment.created_at|date:"d/m/Y - H:i" != comment.updated_at|date:"d/m/Y - H:i" %}
+              <em>
+                ({% trans "Updated" %}: <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.updated_at }}'>{{ comment.updated_at|timesince }} {% trans "ago" %}</a>)
+              </em>
+            {% endif %}
+            {% if request.user == comment.author and comment.ticket.is_open %}
+              <span class='pull-right'>
+                <a href="{% url comment_edit comment.pk %}"><i class="icon-pencil"></i> {% trans "Edit" %}</a>
+              </span>
+            {% endif %}
+          </small>
+        </div>
+        <div class='comment_message_box'>
+          {{ comment.message|urlize_ticket_link|linebreaksbr }}
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+
+  {% empty %}
+    <div class="alert alert-info">
+      <i class="icon-info-sign"></i> {% trans "No comments" %}
+    </div>
+  {% endfor %}
+
 {% endblock %}
 
 {% block extrafooter %}
@@ -143,6 +174,7 @@
         }
         return true;
       });
+      $('.time_ago_tooltip').tooltip();
     });
   </script>
 {% endblock %}

--- a/scielomanager/journalmanager/templatetags/user_avatar.py
+++ b/scielomanager/journalmanager/templatetags/user_avatar.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Usage:
+#
+# {% user_avatar_url user [size_in_px|"small"|"medium"|"large"] %}
+#
+# user:
+# django.contrib.auth.models.User object
+#
+# size_in_px:
+# size of the result avatar (size_in_px x size_in_px)
+#
+# Examples:
+# {% query_string request.user "18" %}
+# {% query_string request.user "small" %}
+# {% query_string request.user "medium" %}
+# {% query_string request.user "large" %}
+
+import urllib
+from django import template
+from django.conf import settings
+
+SIZE_LARGE = 64
+SIZE_MEDIUM = 32
+SIZE_SMALL = 18
+
+register = template.Library()
+def user_avatar_url(user, size):
+    size = size.lower()
+    if size == 'large':
+        size = SIZE_LARGE
+    elif size == 'medium':
+        size = SIZE_MEDIUM
+    elif size == 'small':
+        size = SIZE_SMALL
+    elif size.isdigit() and int(size) > 0:
+        size = int(size)
+    else:
+        return ''
+
+    user_gravatar_id = user.get_profile().gravatar_id
+    params = urllib.urlencode({'s': size, 'd': 'mm'})
+    gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
+    avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_gravatar_id, params)
+    return avartar_url
+
+register.simple_tag(user_avatar_url)

--- a/scielomanager/scielomanager/static/css/style.css
+++ b/scielomanager/scielomanager/static/css/style.css
@@ -280,4 +280,48 @@ table._listings h4 {
 #add_comment_section_row {padding-bottom: 20px;}
 .hide_row {display: none;}
 
+.message_top_arror_box { position: relative; background: #F7F7F7; border: 4px solid #DDD; padding:10px; margin: 20px 0; border-radius: 5px;}
+.message_top_arror_box:after, .message_top_arror_box:before { 
+    bottom: 100%;
+    left: 5%;
+    border: solid transparent;
+    content: " ";
+    height: 0; 
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+}
+.message_top_arror_box:after {
+  border-color: rgba(247, 247, 247, 0);
+  border-bottom-color: #F7F7F7;
+  border-width: 15px;
+  margin-left: -15px;
+}
+.message_top_arror_box:before {
+  border-color: rgba(221, 221, 221, 0);
+  border-bottom-color: #DDD;
+  border-width: 21px;
+  margin-left: -21px;
+}
+
+.comment_left_arrow_box {
+  position: relative; background: #F7F7F7; border: 2px solid #DDD;
+  padding:10px; border-radius: 5px 5px 0 0;
+}
+.comment_left_arrow_box:after, .comment_left_arrow_box:before {
+  right: 100%; top: 50%; border: solid transparent; content: " "; height: 0; width: 0; position: absolute; pointer-events: none;
+}
+.comment_left_arrow_box:after {
+  border-color: rgba(247, 247, 247, 0); border-right-color: #F7F7F7; border-width: 10px; margin-top: -10px;
+}
+.comment_left_arrow_box:before {
+  border-color: rgba(221, 221, 221, 0); border-right-color: #DDD; border-width: 13px; margin-top: -13px;
+}
+.comment_message_box {
+  padding:10px;
+  margin-bottom: 10px;
+  border-radius:  0 0 5px 5px; 
+  border: 2px solid #DDD;
+  border-top: none;
+}
 


### PR DESCRIPTION
Aproveitando a mudança da navegação, fiz uma melhora no visual dos
templates relacionados com os tickets.

[includes/tickets_list_simple.html]
Utiliza o novo template_tag para obter o avatar.
Mensagem de {% empty %} mostrado abaixo do thead, com o markup de aviso,
como nas otras listas.

[checkin_list.html]
botão de +/- mais pequeno.

[notice_detail]
Mensagem de {% empty %} mostrado abaixo do thead, com o markup de aviso,
como nas otras listas.

[ticket_detail.html]
Utiliza o novo template_tag para obter o avatar em diferentes tamanhos
(tamanho em px, ou estandar: large, medium, small).
Nova navegação e novos estilos para os dados do ticket e a lista de
comments.

[user_avatar.py]
template tag para obter o url da imagem do gravatar.
