### PR TITLE
Fix: Feedback do UI #654

### DIFF
--- a/scielomanager/articletrack/templates/articletrack/checkin_list.html
+++ b/scielomanager/articletrack/templates/articletrack/checkin_list.html
@@ -39,7 +39,7 @@
         <td>{{ checkin.article.issue_label }}</td>
         <td>{{ checkin.created_at|date:"d/m/Y - H:i" }}</td>
         <td>
-          <span class="label label-{% trans_status checkin.get_error_level to_label=True %}">
+          <span class="label label-{% trans_status checkin.get_error_level to_label='True' %}">
             {{ checkin.get_error_level }}
           </span>
         </td>

--- a/scielomanager/articletrack/templates/articletrack/notice_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/notice_detail.html
@@ -97,7 +97,7 @@
         {{ notice.stage }}
       </td>
       <td>
-        <span class="label label-{% trans_status notice.status to_label=True%}">
+        <span class="label label-{% trans_status notice.status to_label='True' %}">
           {{ notice.status }}
         </span>
       </td>

--- a/scielomanager/articletrack/templatetags/trans_status.py
+++ b/scielomanager/articletrack/templatetags/trans_status.py
@@ -1,12 +1,12 @@
 from django import template
-
+from scielomanager.tools import asbool
 register = template.Library()
 
 dict_status = {'ok': 'success'}
 label_status_translation = {'ok': 'success', 'error': 'important'}
 
 def trans_status(status, to_label=False):
-    if to_label:
+    if asbool(to_label):
         return label_status_translation.get(status,status)
     return dict_status.get(status, status)
 


### PR DESCRIPTION
- Fix: label para status 'error', a passagem de parametros para este
  caso era considerada como False ou None, e não mostraba a label
  vermelha.
