### PR TITLE
Resíduos de *suppl_volume* e *suppl_number* #742

### DIFF
--- a/scielomanager/export/markupfile.py
+++ b/scielomanager/export/markupfile.py
@@ -3,8 +3,8 @@ from django.conf import settings
 
 from . import bundle
 
-MEDIA_ROOT = settings.MEDIA_ROOT + '/export/'
-MEDIA_URL = settings.MEDIA_URL + '/export/'
+MEDIA_ROOT = settings.MEDIA_ROOT + 'export/'
+MEDIA_URL = settings.MEDIA_URL + 'export/'
 
 standards = {
     'iso690': ('icitat', 'iso', u'iso 690/87 - international standard organization'),
@@ -14,9 +14,11 @@ standards = {
     'apa': ('pcitat', 'apa', u'American Psychological Association'),
 }
 
-L10ISSUEMGS = {'en': (u'No section title', u'No Descriptor', u'Health Sciences Descriptors'),
-        'es': (u'Sín título de sección', u'Ningun Descriptor', u'Descriptores en Ciencia de la Salud'),
-        'pt': (u'Sem título de seção', u'Nenhum Descritor', u'Descritores em Ciência da Saúde')}
+L10ISSUEMGS = {
+    'en': (u'No section title', u'No Descriptor', u'Health Sciences Descriptors'),
+    'es': (u'Sín título de sección', u'Ningun Descriptor', u'Descriptores en Ciencia de la Salud'),
+    'pt': (u'Sem título de seção', u'Nenhum Descritor', u'Descritores em Ciência da Saúde')
+}
 
 issns = {
     'print': 'print_issn',
@@ -84,14 +86,14 @@ class Automata(object):
         return self._journal.acronym.lower()
 
     def __unicode__(self):
-        return '{0};{1};{2}.amd;tg{3}.amd'.format(self.issn,
-            self.citat, self.acron, self.norma_acron)
+        return '{0};{1};{2}.amd;tg{3}.amd'.format(self.issn, self.citat,
+                                                  self.acron, self.norma_acron)
 
 
 class Issue(object):
 
     MONTHS = {1: 'Jan', 2: 'Feb', 3: 'Mar', 4: 'Apr', 5: 'May', 6: 'Jun',
-        7: 'Jul', 8: 'Aug', 9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec'}
+              7: 'Jul', 8: 'Aug', 9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec'}
 
     def __init__(self, issue):
         self._issue = issue
@@ -99,8 +101,8 @@ class Issue(object):
     @property
     def legend(self):
         return u'{0} v.{1} n.{2}'.format(self._issue.journal.title_iso,
-                                unicode(self._issue.volume),
-                                unicode(self._issue.identification))
+                                         unicode(self._issue.volume),
+                                         unicode(self._issue.identification))
 
     @property
     def period(self):
@@ -109,7 +111,7 @@ class Issue(object):
         EX.: Apr/Jun ou Apr/ ou /Jun
         '''
         return '%s/%s' % (self.MONTHS.get(self._issue.publication_start_month, ''),
-             self.MONTHS.get(self._issue.publication_end_month, ''))
+                          self.MONTHS.get(self._issue.publication_end_month, ''))
 
     @property
     def order(self):
@@ -149,16 +151,6 @@ class L10nIssue(Automata, Issue):
         return unicode(v) if v else u''
 
     @property
-    def suppl_volume(self):
-        v = self._issue.suppl_volume
-        return unicode(v) if v else u''
-
-    @property
-    def suppl_number(self):
-        v = self._issue.suppl_number
-        return unicode(v) if v else u''
-
-    @property
     def date_iso(self):
         try:
             month = u'%02d' % self._issue.publication_end_month
@@ -181,9 +173,7 @@ class L10nIssue(Automata, Issue):
         return u';'.join([
             self.short_title,
             self.volume,
-            self.suppl_volume,
             self.number,
-            self.suppl_number,
             self.date_iso,
             self.issn,
             self.status,

--- a/scielomanager/export/tests/tests_markupfiles.py
+++ b/scielomanager/export/tests/tests_markupfiles.py
@@ -709,64 +709,6 @@ class L10nIssueTests(MockerTestCase):
         number = l10nissue.number
         self.assertIsInstance(number, unicode)
 
-    def test_suppl_volume(self):
-        dummy_journal = self.mocker.mock()
-        dummy_issue = self.mocker.mock()
-
-        dummy_issue.suppl_volume
-        self.mocker.result('foo')
-
-        self.mocker.replay()
-
-        l10nissue = self._makeOne(dummy_journal, dummy_issue, 'en')
-
-        suppl_volume = l10nissue.suppl_volume
-        self.assertEqual(suppl_volume, u'foo')
-        self.assertIsInstance(suppl_volume, unicode)
-
-    def test_suppl_volume_must_return_unicode_even_when_empty(self):
-        dummy_journal = self.mocker.mock()
-        dummy_issue = self.mocker.mock()
-
-        dummy_issue.suppl_volume
-        self.mocker.result(None)
-
-        self.mocker.replay()
-
-        l10nissue = self._makeOne(dummy_journal, dummy_issue, 'en')
-
-        suppl_volume = l10nissue.suppl_volume
-        self.assertIsInstance(suppl_volume, unicode)
-
-    def test_suppl_number(self):
-        dummy_journal = self.mocker.mock()
-        dummy_issue = self.mocker.mock()
-
-        dummy_issue.suppl_number
-        self.mocker.result('foo')
-
-        self.mocker.replay()
-
-        l10nissue = self._makeOne(dummy_journal, dummy_issue, 'en')
-
-        suppl_number = l10nissue.suppl_number
-        self.assertEqual(suppl_number, u'foo')
-        self.assertIsInstance(suppl_number, unicode)
-
-    def test_suppl_number_must_return_unicode_even_when_empty(self):
-        dummy_journal = self.mocker.mock()
-        dummy_issue = self.mocker.mock()
-
-        dummy_issue.suppl_number
-        self.mocker.result(None)
-
-        self.mocker.replay()
-
-        l10nissue = self._makeOne(dummy_journal, dummy_issue, 'en')
-
-        suppl_number = l10nissue.suppl_number
-        self.assertIsInstance(suppl_number, unicode)
-
     def test_date_iso(self):
         dummy_journal = self.mocker.mock()
         dummy_issue = self.mocker.mock()
@@ -827,14 +769,8 @@ class L10nIssueTests(MockerTestCase):
         dummy_issue.volume
         self.mocker.result('7')
 
-        dummy_issue.suppl_volume
-        self.mocker.result('foo')
-
         dummy_issue.number
         self.mocker.result('4')
-
-        dummy_issue.suppl_number
-        self.mocker.result('bar')
 
         dummy_issue.publication_end_month
         self.mocker.result(00)
@@ -851,7 +787,7 @@ class L10nIssueTests(MockerTestCase):
         self.mocker.replay()
 
         l10nissue = self._makeOne(dummy_journal, dummy_issue, 'en')
-        expected_issue_meta = u'blitz;7;foo;4;bar;baz0000;1234-1234;1'
+        expected_issue_meta = u'blitz;7;4;baz0000;1234-1234;1'
         self.assertEqual(l10nissue.issue_meta, expected_issue_meta)
 
     def test_issue_meta_must_return_unicode(self):
@@ -867,14 +803,14 @@ class L10nIssueTests(MockerTestCase):
         dummy_issue.volume
         self.mocker.result('7')
 
-        dummy_issue.suppl_volume
-        self.mocker.result('foo')
+        # dummy_issue.suppl_volume
+        # self.mocker.result('foo')
 
         dummy_issue.number
         self.mocker.result('4')
 
-        dummy_issue.suppl_number
-        self.mocker.result('bar')
+        # dummy_issue.suppl_number
+        # self.mocker.result('bar')
 
         dummy_issue.publication_end_month
         self.mocker.result(00)
@@ -1123,7 +1059,6 @@ class L10nAheadTests(MockerTestCase):
 
         date_iso = l10nahead.date_iso
         self.assertIsInstance(date_iso, unicode)
-
 
     def test_status_must_return_always_1(self):
         dummy_journal = self.mocker.mock()

--- a/scielomanager/export/tests/tests_pages.py
+++ b/scielomanager/export/tests/tests_pages.py
@@ -33,6 +33,22 @@ class DownloadMarkupFilesTests(WebTest):
 
         self.assertTemplateUsed(response, 'export/markup_files.html')
 
+    def test_post_to_download_file(self):
+        issue = modelfactories.IssueFactory(
+            journal=self.journal, is_marked_up=False)
+        issue2 = modelfactories.IssueFactory(
+            journal=self.journal, is_marked_up=True)
+
+        form = self.app.get(reverse('export.markupfiles'),
+                            user=self.user).forms[0]
+
+        form.set('journal', self.journal.pk)
+        form['issue'].force_value(issue.pk)
+        response = form.submit()
+        # TODO: Improve the test, I've tried using .follow(), but throws a 404 error, and I can't get why,
+        # because the response.headers['Location'] is a valid link, and I can open it in the browser.
+        self.assertEqual(302, response.status_code)
+
 
 class ListIssuesForMarkupFilesTests(WebTest):
     """

--- a/scielomanager/export/views.py
+++ b/scielomanager/export/views.py
@@ -20,7 +20,7 @@ def markup_files(request):
 
             if form.is_valid():
                 bundle_url = markupfile.generate(form.cleaned_data['journal'],
-                                                form.cleaned_data['issue'])
+                                                 form.cleaned_data['issue'])
                 return redirect(bundle_url)
 
     form = forms.MarkupFilesForm(user=request.user)


### PR DESCRIPTION
Fixes issue #742.
[markupfile.py]
- removi uma `/` antes de: `export/` porque gerava `//`no path
  (`MEDIA_ROOT` termina com barra também).
- `L10ISSUEMGS` et al, removi/adicionei espaçoes para validar com PEP8
- removi as properties: `suppl_volume` e  `suppl_number`

[tests_markupfile.py]
- removi os tests das properties removidas

[tests_pages.py]
- Adicionei um test que faz um submit do form, e avalia uma resposta ok,
  mas o test tem que ser melhorado como diz no comentarios.

[views.py]
- adiciono espaços para validar com PEP8.
