### PR TITLE
Nome da coleção não aparece quando o usuário não tem ``profile`` #759

### DIFF
--- a/scielomanager/journalmanager/backends.py
+++ b/scielomanager/journalmanager/backends.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 
 from journalmanager import models
 
+
 class ModelBackend(ModelBackend):
     """
     Authenticate against the DJANGO login or user e-mail
@@ -26,7 +27,6 @@ class ModelBackend(ModelBackend):
                 return None
 
         return None
-
 
     def get_user(self, user_id):
         try:

--- a/scielomanager/journalmanager/templates/admin/auth/user/change_form.html
+++ b/scielomanager/journalmanager/templates/admin/auth/user/change_form.html
@@ -1,0 +1,26 @@
+{% extends "admin/change_form.html" %}
+{% block after_field_sets %}
+{{ block.super }}
+<script type="text/javascript">
+(function($) {
+    $(document).ready(function() {
+
+        var user_email = $('#id_email');
+        var profile_email = $('#id_userprofile-0-email');
+        var link_copy_from_user = '&nbsp;<a id="copy_email_from_user" href="#">Copy email from User</a>';
+        var link_copy_from_profile = '&nbsp;<a id="copy_email_from_profile" href="#">Copy email from Profile</a>';
+        user_email.after(link_copy_from_profile);
+        profile_email.after(link_copy_from_user);
+
+        $('#copy_email_from_user').click(function(event){
+            event.preventDefault();
+            profile_email.val(user_email.val())
+        });
+        $('#copy_email_from_profile').click(function(event){
+            event.preventDefault();
+            user_email.val(profile_email.val())
+        });
+    });
+})(django.jQuery);;
+</script>
+{% endblock %}

--- a/scielomanager/journalmanager/templates/journalmanager/add_user.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_user.html
@@ -56,20 +56,23 @@
       </div>
     </div>
 
-    {% for form in userprofileformset.forms %}
-    {{ form.id }}
-    <div class="control-group {% if form.email.errors %}error{% endif %}">
+    <div class="control-group {% if add_form.email.errors %}error{% endif %}">
       <label for="{{ add_form.email.auto_id }}">
         <span {% if add_form.email.field.required %}class="req-field"{% endif %}>
-          {% trans form.email.label %}
+          {% trans add_form.email.label %}
         </span>
       </label>
       <div class="controls">
-        {{ form.email }}
+        {{ add_form.email }}
+        {% if add_form.email.errors %}
+          <ul>
+            {% for error in add_form.email.errors %}
+              <li>{{ error }}</li>              
+            {% endfor %}
+          </ul>
+        {% endif %}
       </div>
     </div>
-    {% endfor %}
-    {{ userprofileformset.management_form }}
 
     <div class="control-group {% if add_form.groups.errors %}error{% endif %}">
       <label for="{{ add_form.groups.auto_id }}">

--- a/scielomanager/journalmanager/tests/tests_backend.py
+++ b/scielomanager/journalmanager/tests/tests_backend.py
@@ -4,6 +4,7 @@ from django_factory_boy import auth
 
 from journalmanager.tests import modelfactories
 from journalmanager.backends import ModelBackend
+from journalmanager.models import UserProfile
 
 
 HASH_FOR_123 = 'sha1$93d45$5f366b56ce0444bfea0f5634c7ce8248508c9799'
@@ -17,9 +18,7 @@ class ModelBackendTest(TestCase):
                                password=HASH_FOR_123,
                                email='foo@bar.org',
                                is_active=True)
-        self.profile = modelfactories.UserProfileFactory.build(
-            user=self.user,
-            email=self.user.email).save()
+        self.profile = self.user.userprofile
 
     def test_right_username_and_right_password(self):
         mbkend = ModelBackend()

--- a/scielomanager/journalmanager/tests/tests_forms.py
+++ b/scielomanager/journalmanager/tests/tests_forms.py
@@ -493,8 +493,7 @@ class UserFormTests(WebTest):
         form['user-username'] = 'bazz'
         form['user-first_name'] = 'foo'
         form['user-last_name'] = 'bar'
-        form['userprofile-0-email'] = 'bazz@spam.org'
-        # form.set('asmSelect0', '1')  # groups
+        form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
 
         response = form.submit().follow()
@@ -517,7 +516,7 @@ class UserFormTests(WebTest):
         form['user-username'] = 'bazz'
         form['user-first_name'] = 'foo'
         form['user-last_name'] = 'bar'
-        form['userprofile-0-email'] = 'bazz@spam.org'
+        form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
 
         response = form.submit().follow()
@@ -537,7 +536,7 @@ class UserFormTests(WebTest):
         form['user-username'] = 'bazz'
         form['user-first_name'] = 'foo'
         form['user-last_name'] = 'bar'
-        form['userprofile-0-email'] = 'bazz@spam.org'
+        form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
 
         response = form.submit().follow()
@@ -577,7 +576,7 @@ class UserFormTests(WebTest):
         form['user-username'] = 'bazz'
         form['user-first_name'] = 'foo'
         form['user-last_name'] = 'bar'
-        form['userprofile-0-email'] = 'bazz@spam.org'
+        form['user-email'] = 'bazz@spam.org'
 
         response = form.submit()
 
@@ -602,7 +601,7 @@ class UserFormTests(WebTest):
         form['user-username'] = 'bazz'
         form['user-first_name'] = 'foo'
         form['user-last_name'] = 'bar'
-        form['userprofile-0-email'] = 'bazz@spam.org'
+        form['user-email'] = 'bazz@spam.org'
         # Remove the collection
         form.set('usercollections-0-collection', '')
 

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -99,6 +99,11 @@ class UserProfileTests(TestCase):
 
         self.assertEqual(profile.avatar_url, expected_url)
 
+    def test_create_user_must_create_profile(self):
+        user = auth.UserF(username='foo', password=HASH_FOR_123, is_active=True)
+        profile_exists = models.UserProfile.objects.filter(user=user, email=user.email).exists()
+        self.assertTrue(profile_exists)
+
 
 class IssueTests(TestCase):
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -343,7 +343,6 @@ def add_user(request, user_id=None):
     # Getting Collections from the logged user.
     user_collections = models.get_user_collections(request.user.id)
 
-    UserProfileFormSet = inlineformset_factory(User, models.UserProfile, )
     UserCollectionsFormSet = inlineformset_factory(User, models.UserCollections,
         form=UserCollectionsForm, extra=1, can_delete=True, formset=FirstFieldRequiredFormSet)
 
@@ -352,12 +351,10 @@ def add_user(request, user_id=None):
 
     if request.method == 'POST':
         userform = UserForm(request.POST, instance=user, prefix='user')
-        userprofileformset = UserProfileFormSet(request.POST, instance=user, prefix='userprofile',)
         usercollectionsformset = UserCollectionsFormSet(request.POST, instance=user, prefix='usercollections',)
 
-        if userform.is_valid() and userprofileformset.is_valid() and usercollectionsformset.is_valid():
+        if userform.is_valid() and usercollectionsformset.is_valid():
             new_user = userform.save()
-            userprofileformset.save()
 
             # Clear cache when changes in UserCollections
             invalid = [collection for collection in user_collections]
@@ -382,7 +379,6 @@ def add_user(request, user_id=None):
             messages.error(request, MSG_FORM_MISSING)
     else:
         userform = UserForm(instance=user, prefix='user')
-        userprofileformset = UserProfileFormSet(instance=user, prefix='userprofile',)
         usercollectionsformset = UserCollectionsFormSet(instance=user, prefix='usercollections',)
 
     return render_to_response('journalmanager/add_user.html', {
@@ -390,7 +386,6 @@ def add_user(request, user_id=None):
                               'mode': 'user_journal',
                               'user_name': request.user.pk,
                               'usercollectionsformset': usercollectionsformset,
-                              'userprofileformset': userprofileformset
                               },
                               context_instance=RequestContext(request))
 

--- a/scielomanager/scielomanager/utils/modelmanagers/helpers.py
+++ b/scielomanager/scielomanager/utils/modelmanagers/helpers.py
@@ -68,5 +68,4 @@ def _makeUserProfile(user):
     """
     from journalmanager.models import UserProfile
 
-    profile = UserProfile(user=user, email=user.email)
-    profile.save()
+    profile, created = UserProfile.objects.get_or_create(user=user, email=user.email)


### PR DESCRIPTION
- adiciono signal para criar um objeto `UserProfile` no momento
  (`post_save`) de cria um objeto tipo User.
- No admin, o campo emial tem um js que ajuda na copia do campo email
  entre o User e o UserProfile.
- adiciono campo `email` no formulario usado para adicionar usuario,
  como campo obrigatorio
- removido o formset do profile, utilizado para mostar o email do
  `UserProfile`, no lugar agora é usado o email do `User`
- ajustes nos tests.
- No helper `_makeUserProfile` agora não cria o profile sempre. Só
  quando é necessário.
