### PR TITLE
Novos usuários são criados sem definir uma coleção ativa. #858

### DIFF
--- a/scielomanager/journalmanager/forms.py
+++ b/scielomanager/journalmanager/forms.py
@@ -753,6 +753,7 @@ class UserCollectionsForm(ModelForm):
 
     class Meta:
         model = models.UserCollections
+        exclude = ('is_default', )
         widgets = {
             'collection': forms.Select(attrs={'class': 'span8'}),
         }
@@ -803,19 +804,3 @@ class FirstFieldRequiredFormSet(BaseInlineFormSet):
                 pass
         if count < 1:
             raise forms.ValidationError(_('Please fill in at least one form'))
-
-
-class OnlyOneDefaultCollectionRequiredFormSet(FirstFieldRequiredFormSet):
-    def clean(self):
-        super(OnlyOneDefaultCollectionRequiredFormSet, self).clean()
-        count = 0
-        for form in self.forms:
-            try:
-                if form.cleaned_data and form.cleaned_data.get('is_default', False):
-                    count += 1
-            except AttributeError:
-                pass
-        if count < 1:
-            raise forms.ValidationError(_('At least one collection is required to be set as default'))
-        elif count > 1:
-            raise forms.ValidationError(_('Only one collection can be set as default!'))

--- a/scielomanager/journalmanager/templates/journalmanager/add_user.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_user.html
@@ -18,7 +18,7 @@
 
   {% for error in add_form.non_field_errors %}
     <div class="alert alert-error">
-      <button class="close" data-dismiss="alert" type="button">&times;</button> 
+      <button class="close" data-dismiss="alert" type="button">&times;</button>
       <strong>{{ error }}</strong>
     </div>
   {% endfor %}
@@ -74,7 +74,7 @@
         {% if add_form.email.errors %}
           <ul>
             {% for error in add_form.email.errors %}
-              <li>{{ error }}</li>              
+              <li>{{ error }}</li>
             {% endfor %}
           </ul>
         {% endif %}
@@ -94,6 +94,7 @@
   </div>
 
 {% if usercollectionsformset.non_form_errors %}
+  {# non form errors #}
   <div class="alert alert-error">
     <button class="close" data-dismiss="alert" type="button">×</button>
     {% for non_form_error in usercollectionsformset.non_form_errors %}
@@ -103,6 +104,7 @@
 {% endif %}
 
   <h2>{% trans "User Collections" %}:</h2>
+  <span class="label label-info">{% trans "The first collection will be set as default" %}</span>
   <div class="well">
     <table id="usercollectionsformset" class="table table-bordered table-striped">
       <thead>
@@ -111,7 +113,6 @@
           	{% field_help usercollectionsformset.forms.0.collection.label usercollectionsformset.forms.0.collection.help_text term-collections %}
           </th>
           <th>{% trans "is manager" %}</th>
-          <th>{% trans "is default" %}</th>
           <th>{% trans "options" %}</th>
         </tr>
       </thead>
@@ -119,20 +120,39 @@
         {% for form in usercollectionsformset.forms %}
         <tr id="{{ form.prefix }}-row">
           <td>
+            {# non field errors #}
+            {% if form.non_field_errors %}
+              <div class="alert alert-error">
+                {% for non_field_error in form.non_field_errors %}
+                  {{ non_field_error }}
+                {% endfor %}
+              </div>
+            {% endif %}
             <div class="control-group {% if form.collection.errors %}error{% endif %}">
               {% for field in form.hidden_fields %}{{ field }}{% endfor %}
               {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
               {{ form.collection }}
+              {# collection field errors #}
+              {% if form.collection.errors %}
+                <div class="alert alert-error">
+                  {% for error in form.collection.errors %}
+                    {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
             </div>
           </td>
           <td>
             <div class="control-group {% if add_form.is_manager.errors %}error{% endif %}">
               {{ form.is_manager }}
-            </div>
-          </td>
-          <td>
-            <div class="control-group {% if add_form.is_default.errors %}error{% endif %}">
-              {{ form.is_default }}
+              {% if form.is_manager.errors %}
+                {# is_manager field errors #}
+                <div class="alert alert-error">
+                  {% for error in form.is_manager.errors %}
+                    {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
             </div>
           </td>
           <td></td>

--- a/scielomanager/journalmanager/tests/tests_forms.py
+++ b/scielomanager/journalmanager/tests/tests_forms.py
@@ -497,7 +497,6 @@ class UserFormTests(WebTest):
         form['user-last_name'] = 'bar'
         form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
-        form['usercollections-0-is_default'] = True
 
         response = form.submit().follow()
 
@@ -521,7 +520,6 @@ class UserFormTests(WebTest):
         form['user-last_name'] = 'bar'
         form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
-        form['usercollections-0-is_default'] = True
 
         response = form.submit().follow()
 
@@ -542,7 +540,6 @@ class UserFormTests(WebTest):
         form['user-last_name'] = 'bar'
         form['user-email'] = 'bazz@spam.org'
         form.set('usercollections-0-collection', self.collection.pk)
-        form['usercollections-0-is_default'] = True
 
         response = form.submit().follow()
 
@@ -695,8 +692,8 @@ class UserFormTests(WebTest):
         self.assertTemplateUsed(response, 'journalmanager/add_user.html')
         self.assertEqual([u'Please fill in at least one form'], response.context['usercollectionsformset'].non_form_errors())
 
-    def test_create_user_with_coll_but_not_default_must_fail(self):
-        """ When create a new user, if one collecttion  were added but no is default, must fail """
+    def test_create_user_with_coll_must_set_a_default(self):
+        """ When create a new user, one collecttion must be set as default """
         perm = _makePermission(perm='change_user', model='user', app_label='auth')
         self.user.user_permissions.add(perm)
 
@@ -708,11 +705,13 @@ class UserFormTests(WebTest):
         # filled collection selected, but not setted as default
         form.set('usercollections-0-collection', self.collection.pk)
 
-        response = form.submit()
-        self.assertTemplateUsed(response, 'journalmanager/add_user.html')
+        response = form.submit().follow()
+
+        self.assertTemplateUsed(response, 'journalmanager/user_list.html')
+        self.assertEqual(1, len(self.user.usercollections_set.filter(is_default=True)))
         self.assertEqual(
-            [u'At least one collection is required to be set as default'],
-            response.context['usercollectionsformset'].non_form_errors()
+            self.collection.pk,
+            self.user.usercollections_set.get(is_default=True).collection.pk
         )
 
     def test_create_user_with_only_one_default_coll_must_succeed(self):
@@ -727,7 +726,6 @@ class UserFormTests(WebTest):
         form['user-email'] = 'bazz@spam.org'
         # filled collection selected, but not setted as default
         form.set('usercollections-0-collection', self.collection.pk)
-        form['usercollections-0-is_default'] = True
 
         response = form.submit().follow()
 
@@ -735,8 +733,7 @@ class UserFormTests(WebTest):
         response.mustcontain('bazz', 'bazz@spam.org')
 
         # check if basic state has been set
-        self.assertTrue(response.context['user'].user_collection.get(
-            pk=self.collection.pk))
+        self.assertTrue(response.context['user'].user_collection.get(pk=self.collection.pk))
 
 
 class UserCollectionsFormSetTests(TestCase):
@@ -759,7 +756,7 @@ class UserCollectionsFormSetTests(TestCase):
         UserCollectionsFormSet = inlineformset_factory(
             User, models.UserCollections,
             form=forms.UserCollectionsForm, extra=1, can_delete=True,
-            formset=forms.OnlyOneDefaultCollectionRequiredFormSet
+            formset=forms.FirstFieldRequiredFormSet
         )
         data = {
             'usercollections-TOTAL_FORMS': '2',
@@ -768,12 +765,10 @@ class UserCollectionsFormSetTests(TestCase):
 
             'usercollections-0-id': None,
             'usercollections-0-collection': '%s' % self.collection.pk,
-            'usercollections-0-is_default': True,
             'usercollections-0-is_manager': '',
 
             'usercollections-1-id': None,
             'usercollections-1-collection': '%s' % other_collection.pk,
-            'usercollections-1-is_default': '',
             'usercollections-1-is_manager': '',
         }
 
@@ -791,7 +786,7 @@ class UserCollectionsFormSetTests(TestCase):
         UserCollectionsFormSet = inlineformset_factory(
             User, models.UserCollections,
             form=forms.UserCollectionsForm, extra=1, can_delete=True,
-            formset=forms.OnlyOneDefaultCollectionRequiredFormSet
+            formset=forms.FirstFieldRequiredFormSet
         )
         data = {
             'usercollections-TOTAL_FORMS': '2',
@@ -800,12 +795,10 @@ class UserCollectionsFormSetTests(TestCase):
 
             'usercollections-0-id': None,
             'usercollections-0-collection': '%s' % self.collection.pk,
-            'usercollections-0-is_default': True,
             'usercollections-0-is_manager': '',
 
             'usercollections-1-id': None,
             'usercollections-1-collection': '%s' % self.collection.pk,
-            'usercollections-1-is_default': '',
             'usercollections-1-is_manager': '',
         }
 
@@ -816,20 +809,19 @@ class UserCollectionsFormSetTests(TestCase):
         expected_errors = {'__all__': [u'User collections with this User and Collection already exists.']}
         self.assertEqual(formset.forms[1].errors, expected_errors)
 
-    def test_create_formset_with_two_default_collections_is_not_valid(self):
+    def test_create_formset_with_two_collections_only_the_first_is_set_as_default(self):
         """
         Test if is possible to create a formset with a basic setup of 2 forms,
-        each form will have different collections associated,
-        and both forms will set the associated collections as default.
+        each form will have different collections associated
 
-        The formset must be invalid, because only ONE collection can be set as default
+        The formset must be valid, with only the first collection setted as default
         """
         other_collection = modelfactories.CollectionFactory.create()
 
         UserCollectionsFormSet = inlineformset_factory(
             User, models.UserCollections,
             form=forms.UserCollectionsForm, extra=1, can_delete=True,
-            formset=forms.OnlyOneDefaultCollectionRequiredFormSet
+            formset=forms.FirstFieldRequiredFormSet
         )
         data = {
             'usercollections-TOTAL_FORMS': '2',
@@ -838,22 +830,19 @@ class UserCollectionsFormSetTests(TestCase):
 
             'usercollections-0-id': None,
             'usercollections-0-collection': '%s' % self.collection.pk,
-            'usercollections-0-is_default': True,
             'usercollections-0-is_manager': '',
 
             'usercollections-1-id': None,
             'usercollections-1-collection': '%s' % other_collection.pk,
-            'usercollections-1-is_default': True,
             'usercollections-1-is_manager': '',
         }
 
         formset = UserCollectionsFormSet(data, instance=self.user, prefix='usercollections',)
-
-        self.assertFalse(formset.is_valid())
+        self.assertTrue(formset.is_valid())
         self.assertTrue(formset.forms[0].is_valid())
         self.assertTrue(formset.forms[1].is_valid())
-        expected_errors = [u'Only one collection can be set as default!']
-        self.assertEqual(formset.non_form_errors(), expected_errors)
+        self.assertEqual(1, len(self.user.usercollections_set.filter(is_default=True)))
+        self.assertEqual(self.collection, self.user.usercollections_set.get(is_default=True).collection)
 
     def test_create_formset_with_one_default_and_two_manager_collections_is_valid(self):
         """
@@ -868,7 +857,7 @@ class UserCollectionsFormSetTests(TestCase):
         UserCollectionsFormSet = inlineformset_factory(
             User, models.UserCollections,
             form=forms.UserCollectionsForm, extra=1, can_delete=True,
-            formset=forms.OnlyOneDefaultCollectionRequiredFormSet
+            formset=forms.FirstFieldRequiredFormSet
         )
         data = {
             'usercollections-TOTAL_FORMS': '2',
@@ -877,12 +866,10 @@ class UserCollectionsFormSetTests(TestCase):
 
             'usercollections-0-id': None,
             'usercollections-0-collection': '%s' % self.collection.pk,
-            'usercollections-0-is_default': True,
             'usercollections-0-is_manager': True,
 
             'usercollections-1-id': None,
             'usercollections-1-collection': '%s' % other_collection.pk,
-            'usercollections-1-is_default': '',
             'usercollections-1-is_manager': True,
         }
 
@@ -891,20 +878,22 @@ class UserCollectionsFormSetTests(TestCase):
         self.assertTrue(formset.is_valid())
         self.assertTrue(formset.forms[0].is_valid())
         self.assertTrue(formset.forms[1].is_valid())
+        self.assertEqual(1, len(self.user.usercollections_set.filter(is_default=True)))
+        self.assertEqual(self.collection, self.user.usercollections_set.get(is_default=True).collection)
 
-    def test_create_formset_without_default_collections_is_not_valid(self):
+    def test_create_formset_without_managed_collections_is_valid(self):
         """
         Test if is possible to create a formset with a basic setup of 2 forms,
-        each one with a collection associated, and none of them was set as default.
+        each one with a collection associated, and none of them was set as is_manager.
 
-        The formset must be invalid
+        The formset must be valid, and self.collection must be set as default
         """
         other_collection = modelfactories.CollectionFactory.create()
 
         UserCollectionsFormSet = inlineformset_factory(
             User, models.UserCollections,
             form=forms.UserCollectionsForm, extra=1, can_delete=True,
-            formset=forms.OnlyOneDefaultCollectionRequiredFormSet
+            formset=forms.FirstFieldRequiredFormSet
         )
         data = {
             'usercollections-TOTAL_FORMS': '2',
@@ -913,22 +902,20 @@ class UserCollectionsFormSetTests(TestCase):
 
             'usercollections-0-id': None,
             'usercollections-0-collection': '%s' % self.collection.pk,
-            'usercollections-0-is_default': '',
             'usercollections-0-is_manager': '',
 
             'usercollections-1-id': None,
             'usercollections-1-collection': '%s' % other_collection.pk,
-            'usercollections-1-is_default': '',
             'usercollections-1-is_manager': '',
         }
 
         formset = UserCollectionsFormSet(data, instance=self.user, prefix='usercollections',)
 
-        self.assertFalse(formset.is_valid())
+        self.assertTrue(formset.is_valid())
         self.assertTrue(formset.forms[0].is_valid())
         self.assertTrue(formset.forms[1].is_valid())
-        expected_errors = [u'At least one collection is required to be set as default']
-        self.assertEqual(formset.non_form_errors(), expected_errors)
+        self.assertEqual(1, len(self.user.usercollections_set.filter(is_default=True)))
+        self.assertEqual(self.collection, self.user.usercollections_set.get(is_default=True).collection)
 
 
 class JournalFormTests(WebTest):
@@ -951,8 +938,7 @@ class JournalFormTests(WebTest):
         are unable to access the form. They must be redirected to a page
         with informations about their lack of permissions.
         """
-        response = self.app.get(reverse('journal.add'),
-            user=self.user).follow()
+        response = self.app.get(reverse('journal.add'), user=self.user).follow()
 
         response.mustcontain('not authorized to access')
         self.assertTemplateUsed(response, 'accounts/unauthorized.html')
@@ -989,8 +975,7 @@ class JournalFormTests(WebTest):
         form is rendered again and an alert is shown with the message
         ``There are some errors or missing data``.
         """
-        perm = _makePermission(perm='change_journal',
-            model='journal', app_label='journalmanager')
+        perm = _makePermission(perm='change_journal', model='journal', app_label='journalmanager')
         self.user.user_permissions.add(perm)
 
         sponsor = modelfactories.SponsorFactory.create()


### PR DESCRIPTION
Fixes: #858

[forms.py]
- removido exclude para mostrar o campo `is_default` do modelo.
- adiciono `OnlyOneDefaultCollectionRequiredFormSet` especializacão do
  formset `FirstFieldRequiredFormSet` con validação na quantidade de
  collections marcadas com: `is_default = True` nos inlines.

[templates/journalmanager/add_user]
- adiciono a coluna para campo: `is_default`
- melhora no display de erros

[views.py]
- troca de `FirstFieldRequiredFormSet` por
  `OnlyOneDefaultCollectionRequiredFormSet`

[test_forms.py]
- fix de tests, que agora tem que indicar o campo: `is_default`
- adiciono tests do form: `UserForm`
- adiciono `UserCollectionsFormSetTests` com varios test sobre o
  formset: `UserCollectionsFormSet`
