### PR TITLE
 Editar Journal status: mostar errors nos campos do form #885 

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/edit_journal_status.html
+++ b/scielomanager/journalmanager/templates/journalmanager/edit_journal_status.html
@@ -45,7 +45,8 @@
     <tbody>
   </table>
 </div>
-<form id="journal-status-form" method="post" action="">
+
+<form id="journal-status-form" method="post" action="" class="form-horizontal">
   {% csrf_token %}
   <h2>{% trans "Change Status" %}:</h2>
   <div class="well">
@@ -53,26 +54,19 @@
       <i class="icon-info-sign"></i>
       {% trans 'Be aware of this modification, once it could not be undone.' %}
     </div>
-    <div class="control-group {% if add_form.status.errors %}error{% endif %}">
-      <label for="{{ add_form.status.auto_id }}">
-        <span {% if add_form.status.field.required %}class="req-field"{% endif %}>
-          {% trans add_form.status.label %}
-        </span>
-      </label>
-      <div class="controls">
-        {{ add_form.status }}
+
+    {% if add_form.non_field_errors %}
+      <div class="alert alert-block alert-error">
+        <ul>
+          {% for errors in add_form.non_field_errors %}
+            <li>{{ errors }}</li>
+          {% endfor %}
+        </ul>
       </div>
-    </div>
-    <div class="control-group {% if add_form.reason.errors %}error{% endif %}">
-      <label for="{{ add_form.reason.auto_id }}">
-        <span {% if add_form.reason.field.required %}class="req-field"{% endif %}>
-          {% trans add_form.reason.label %}
-        </span>
-      </label>
-      <div class="controls">
-        {{ add_form.reason }}
-      </div>
-    </div>
+    {% endif %}
+    {% for field in add_form %}
+      {% include "journalmanager/includes/form_field_row.html" %}
+    {% endfor %}
   </div>
   <div class="row-fluid">
       <input

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -407,7 +407,6 @@ def edit_journal_status(request, journal_id=None):
     if request.method == "POST":
         membership = journal.membership_info(current_user_collection)
         membershipform = MembershipForm(request.POST, instance=membership)
-
         if membershipform.is_valid():
             membershipform.save_all(request.user, journal, current_user_collection)
             messages.info(request, MSG_FORM_SAVED)
@@ -415,8 +414,8 @@ def edit_journal_status(request, journal_id=None):
                 'journal_status.edit', kwargs={'journal_id': journal_id}))
         else:
             messages.error(request, MSG_FORM_MISSING)
-
-    membershipform = MembershipForm()
+    else:
+        membershipform = MembershipForm()
 
     return render_to_response('journalmanager/edit_journal_status.html', {
                               'add_form': membershipform,


### PR DESCRIPTION
Fixes: #885 

[views.py]
- adiciono `else:` porque a linha `membershipform =
  MembershipForm()` limpava os erros do form.

[test_pages.py]
- tests para o caso de exito, e o caso de não preencher um campo e gera
  erro.

[templates/journalmanager/edit_journal_status.html]
- refactor do templates para reutilizar o include mais generico, e com o
  mesmo estilo que o template de editar journal.
- adiciono listas de errors de form.
