### PR TITLE
Incluindo atributo na API para periódico que sucede de outro periódico registrado no SciELO Manager.

### DIFF
--- a/scielomanager/api/resources.py
+++ b/scielomanager/api/resources.py
@@ -205,6 +205,7 @@ class JournalResource(ModelResource):
 
     #recursive field
     previous_title = fields.ForeignKey('self', 'previous_title', null=True)
+    succeeding_title = fields.ForeignKey('self', 'succeeding_title', null=True)
 
     class Meta(ApiKeyAuthMeta):
         queryset = Journal.objects.all().filter()

--- a/scielomanager/api/tests.py
+++ b/scielomanager/api/tests.py
@@ -207,6 +207,7 @@ class JournalRestAPITest(WebTest):
             u'current_ahead_documents',
             u'twitter_user',
             u'previous_title',
+            u'succeeding_title',
         ]
 
         json_keys = set(response.json.keys())
@@ -302,6 +303,40 @@ class JournalRestAPITest(WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content)['objects']), 1)
         self.assertEqual(json.loads(response.content)['objects'][0]['eletronic_issn'], '1234-1234')
+
+    def test_succeding_title(self):
+        col = modelfactories.CollectionFactory()
+
+        col.add_user(self.user)
+
+        journal1 = modelfactories.JournalFactory.create(title='Previous Title')
+        journal1.join(col, self.user)
+
+        journal2 = modelfactories.JournalFactory.create(title='Succeeding Title', previous_title=journal1)
+        journal2.join(col, self.user)
+
+        response = self.app.get(
+            '/api/v1/journals/%s/' % journal1.pk,
+            extra_environ=self.extra_environ).json
+
+        self.assertEqual(
+            response['succeeding_title'],
+            '/api/v1/journals/%s/' % journal2.pk)
+
+    def test_without_succeding_title(self):
+        col = modelfactories.CollectionFactory()
+
+        col.add_user(self.user)
+
+        journal1 = modelfactories.JournalFactory.create(title='Previous Title')
+        journal1.join(col, self.user)
+
+        response = self.app.get(
+            '/api/v1/journals/%s/' % journal1.pk,
+            extra_environ=self.extra_environ).json
+
+        self.assertEqual(
+            response['succeeding_title'], None)
 
     def test_dehydrate_pub_status_with_one_collections(self):
         col = modelfactories.CollectionFactory()

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -616,6 +616,13 @@ class Journal(caching.base.CachingMixin, models.Model):
 
         return grid
 
+    @property
+    def succeeding_title(self):
+        try:
+            return self.prev_title.get()
+        except ObjectDoesNotExist:
+            return None
+
     def has_issues(self, issues):
         """
         Returns ``True`` if all the given issues are bound to the journal.

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -316,8 +316,25 @@ class JournalTests(TestCase):
         Restore the default values.
         """
 
+    def test_succeeding_title(self):
+        journal1 = JournalFactory.create(title='uPrevious Title')
+
+        journal2 = JournalFactory.create(title=u'Succeeding Title', previous_title=journal1)
+
+        result = journal1.succeeding_title
+
+        self.assertEqual(result.title, u'Succeeding Title')
+
+    def test_without_succeeding_title(self):
+        journal1 = JournalFactory.create(title=u'Previous Title')
+
+        result = journal1.succeeding_title
+
+        self.assertEqual(result, None)
+
     def test_valid_is_editors(self):
         user = auth.UserF()
+
         journal = JournalFactory.create()
 
         journal.editors.add(user)


### PR DESCRIPTION
fix #887
