### PR TITLE
FIX requirements.txt: django-htmlmin.git is not the right format; it must have #egg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pymongo
 jsonfield
 django-tastypie==0.9.14
 django-waffle==0.9.1
--e git+git://github.com/scieloorg/django-htmlmin.git
+-e git+git://github.com/scieloorg/django-htmlmin.git#egg=django-htmlmin
 -e git+git://github.com/scieloorg/django-cache-machine.git#egg=django-cache-machine
 -e git+git://github.com/scieloorg/packtools.git#egg=packtools
 Celery


### PR DESCRIPTION
Msg de erro gerado no Travis:

```
pip install -r requirements.txt --use-mirrors
...
--editable=git+git://github.com/scieloorg/django-htmlmin.git is not the
right format; it must have #egg=Package

Storing debug log for failure in /home/travis/.pip/pip.log
```
