### PR TITLE
Criar task para invocação de ``proceed_to_checkout`` no balaioRPC #669

### DIFF
--- a/scielomanager/api/tests.py
+++ b/scielomanager/api/tests.py
@@ -1236,7 +1236,6 @@ class CheckinRestAPITest(WebTest):
                 u'accepted_at',
                 u'article',
                 u'attempt_ref',
-                u'checked_out',
                 u'created_at',
                 u'expiration_at',
                 u'id',

--- a/scielomanager/articletrack/migrations/0014_auto__del_field_checkin_checked_out__chg_field_checkin_status.py
+++ b/scielomanager/articletrack/migrations/0014_auto__del_field_checkin_checked_out__chg_field_checkin_status.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Checkin.checked_out'
+        db.delete_column('articletrack_checkin', 'checked_out')
+
+
+        # Changing field 'Checkin.status'
+        db.alter_column('articletrack_checkin', 'status', self.gf('django.db.models.fields.CharField')(max_length=20))
+
+    def backwards(self, orm):
+        # Adding field 'Checkin.checked_out'
+        db.add_column('articletrack_checkin', 'checked_out',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+        # Changing field 'Checkin.status'
+        db.alter_column('articletrack_checkin', 'status', self.gf('django.db.models.fields.CharField')(max_length=10))
+
+    models = {
+        'articletrack.article': {
+            'Meta': {'object_name': 'Article'},
+            'article_title': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'articlepkg_ref': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'eissn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '9'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue_label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'journal_title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'journals': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'checkin_articles'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'pissn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '9'})
+        },
+        'articletrack.checkin': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'Checkin'},
+            'accepted_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'accepted_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'checkins'", 'null': 'True', 'to': "orm['articletrack.Article']"}),
+            'attempt_ref': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'expiration_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package_name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'rejected_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'rejected_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_rejected'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'rejected_cause': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'reviewed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'reviewed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'scielo_reviewed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'scielo_reviewed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_scielo_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '20'}),
+            'submitted_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_submitted_by'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'uploaded_at': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'articletrack.checkinworkflowlog': {
+            'Meta': {'ordering': "['created_at']", 'object_name': 'CheckinWorkflowLog'},
+            'checkin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submission_log'", 'to': "orm['articletrack.Checkin']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '10'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkin_log_responsible'", 'null': 'True', 'to': "orm['auth.User']"})
+        },
+        'articletrack.comment': {
+            'Meta': {'ordering': "['created_at']", 'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments_author'", 'to': "orm['auth.User']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': "orm['articletrack.Ticket']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'articletrack.notice': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'Notice'},
+            'checkin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'notices'", 'to': "orm['articletrack.Checkin']"}),
+            'checkpoint': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'stage': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'articletrack.team': {
+            'Meta': {'object_name': 'Team'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'member': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'team'", 'symmetrical': 'False', 'to': "orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'})
+        },
+        'articletrack.ticket': {
+            'Meta': {'ordering': "['started_at']", 'object_name': 'Ticket'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tickets'", 'to': "orm['articletrack.Article']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tickets'", 'to': "orm['auth.User']"}),
+            'finished_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editors': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'user_editors'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['auth.User']"}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['articletrack']

--- a/scielomanager/articletrack/migrations/0015_auto__chg_field_checkinworkflowlog_status.py
+++ b/scielomanager/articletrack/migrations/0015_auto__chg_field_checkinworkflowlog_status.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'CheckinWorkflowLog.status'
+        db.alter_column('articletrack_checkinworkflowlog', 'status', self.gf('django.db.models.fields.CharField')(max_length=20))
+
+    def backwards(self, orm):
+
+        # Changing field 'CheckinWorkflowLog.status'
+        db.alter_column('articletrack_checkinworkflowlog', 'status', self.gf('django.db.models.fields.CharField')(max_length=10))
+
+    models = {
+        'articletrack.article': {
+            'Meta': {'object_name': 'Article'},
+            'article_title': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'articlepkg_ref': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'eissn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '9'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue_label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'journal_title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'journals': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'checkin_articles'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'pissn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '9'})
+        },
+        'articletrack.checkin': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'Checkin'},
+            'accepted_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'accepted_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'checkins'", 'null': 'True', 'to': "orm['articletrack.Article']"}),
+            'attempt_ref': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'expiration_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package_name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'rejected_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'rejected_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_rejected'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'rejected_cause': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'reviewed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'reviewed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'scielo_reviewed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'scielo_reviewed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_scielo_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '20'}),
+            'submitted_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkins_submitted_by'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'uploaded_at': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'articletrack.checkinworkflowlog': {
+            'Meta': {'ordering': "['created_at']", 'object_name': 'CheckinWorkflowLog'},
+            'checkin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submission_log'", 'to': "orm['articletrack.Checkin']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '20'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'checkin_log_responsible'", 'null': 'True', 'to': "orm['auth.User']"})
+        },
+        'articletrack.comment': {
+            'Meta': {'ordering': "['created_at']", 'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments_author'", 'to': "orm['auth.User']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': "orm['articletrack.Ticket']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'articletrack.notice': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'Notice'},
+            'checkin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'notices'", 'to': "orm['articletrack.Checkin']"}),
+            'checkpoint': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'stage': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'articletrack.team': {
+            'Meta': {'object_name': 'Team'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'member': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'team'", 'symmetrical': 'False', 'to': "orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'})
+        },
+        'articletrack.ticket': {
+            'Meta': {'ordering': "['started_at']", 'object_name': 'Ticket'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tickets'", 'to': "orm['articletrack.Article']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tickets'", 'to': "orm['auth.User']"}),
+            'finished_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editors': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'user_editors'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['auth.User']"}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['articletrack']

--- a/scielomanager/articletrack/tasks.py
+++ b/scielomanager/articletrack/tasks.py
@@ -5,8 +5,13 @@ import logging
 from .balaio import BalaioRPC
 from .models import Checkin
 from scielomanager.celery import app
-
+from .utils import checkin_send_email_by_action
 logger = logging.getLogger(__name__)
+
+
+# ################## #
+# CHECKIN EXPIRATION #
+# ################## #
 
 
 @app.task(bind=True)
@@ -48,3 +53,55 @@ def process_expirable_checkins(self):
             do_expires_checkin.apply_async(args=[checkin, ])
 
     logger.debug('[process_expirable_checkins] FINISH process at %s' % datetime.datetime.now())
+
+
+# ########################### #
+# CHECKIN PROCEED TO CHECKOUT #
+# ########################### #
+
+
+@app.task(bind=True)
+def do_proceed_to_checkout(self, checkin_id):
+    """
+    Call balaio to process checkin and proceed to checkout, if checkin comply with requirements
+    """
+    logger.debug('[do_proceed_to_checkout] START process to proceed with checkout of Checkin (pk=%s) at %s' % (checkin_id, datetime.datetime.now()))
+    rpc_client = BalaioRPC()
+
+    try:
+        checkin = Checkin.objects.get(pk=checkin_id)
+    except Checkin.DoesNotExist as e:
+        logger.error('[do_proceed_to_checkout] FAIL while retrieving checkin (pk: %s), Checkin does not exist' % e)
+
+    if checkin.is_scheduled_to_checkout:
+        try:
+            rpc_response = rpc_client.call('proceed_to_checkout', [checkin.attempt_ref, ])
+        except Exception as e:
+            logger.error('[do_proceed_to_checkout] FAIL, retrying. Exception: %s' % e)
+            raise self.retry(exc=e)
+        else:
+            if rpc_response:
+                checkin.do_confirm_checkout()
+                logger.info('[do_proceed_to_checkout] Checkin (pk: %s) proceed to checkout successfully' % checkin_id)
+                # notify users:
+                checkin_send_email_by_action(checkin, 'checkout_confirmed')
+            else:
+                logger.error('BalaioRPC API method: "proceed_to_checkout" FAIL for checkin: %s. Response: %s' % (checkin.pk, rpc_response))
+    else:
+        logger.info('[do_proceed_to_checkout] Checkin does not comply the requirements to proceed to checkout')
+
+    logger.debug('[do_proceed_to_checkout] FINISH process at %s' % datetime.datetime.now())
+
+
+@app.task(bind=True)
+def process_checkins_scheduled_to_checkout(self):
+    logger.debug("[process_checkins_scheduled_to_checkout] START process at %s" % datetime.datetime.now())
+
+    checkins = Checkin.objects.filter(status='checkout_scheduled')
+    logger.info('[process_checkins_scheduled_to_checkout] Found %s checkins matching conditions' % checkins.count())
+
+    for checkin in checkins:
+        logger.info('[process_checkins_scheduled_to_checkout] Processing checkin (pk=%s)' % checkin.pk)
+        do_proceed_to_checkout.apply_async(args=[checkin.pk, ])
+
+    logger.debug('[process_checkins_scheduled_to_checkout] FINISH process at %s' % datetime.datetime.now())

--- a/scielomanager/articletrack/templates/articletrack/checkin_history.html
+++ b/scielomanager/articletrack/templates/articletrack/checkin_history.html
@@ -41,17 +41,24 @@
 
     <div class="log-item row-fluid show-grid">
       <div class="span1">
-        <img class="img-rounded" src="{% user_avatar_url log.user 'medium' %}" alt="{{ log.user.get_full_name }}">
-        <br>
-        <small>{{ log.user.get_full_name }}</small>
+        {% if log.user %}
+          <img class="img-rounded" src="{% user_avatar_url log.user 'medium' %}" alt="{{ log.user.get_full_name }}">
+          <br>
+          <small>{{ log.user.get_full_name }}</small>
+        {% else %}
+          {# some operations as made by task, no user involved, so log are generated without a user #}
+          <i class="icon-cog"></i><i class="icon-cog"></i><i class="icon-cog"></i>
+          <br>
+          <small>{% trans "System" %}</small>
+        {% endif %}
       </div>
       <div class="span11">
         <div class='comment_left_arrow_box'>
           <small>
             <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ log.created_at }}'>
               {{ log.created_at|timesince }} {% trans "ago" %}
-            </a> 
-            {% trans "has modified this checkin status to" %}: 
+            </a>
+            {% trans "has modified this checkin status to" %}:
             {% if log.status == 'pending' %}
               <span class="label">
             {% elif log.status == 'rejected' %}
@@ -74,7 +81,7 @@
           </div>
       </div>
     </div>
-    <div class="down_arrow_icon"> 
+    <div class="down_arrow_icon">
       {% if not forloop.last %}
         <i class="icon-chevron-down"></i>
       {% else %}

--- a/scielomanager/articletrack/templates/articletrack/includes/article_and_checkin_information.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/article_and_checkin_information.html
@@ -7,16 +7,21 @@
       <h2><small>{% trans "Package" %}:</small> {{ checkin.package_name }}</h2>
     </div>
     <div class="row-fluid show-grid">
-      <div class="span6 well">
-        <h4>{% trans "Article Information" %}:</h4>
-        <dl class="dl-horizontal">
-          <dt>{% trans "Title" %}</dt>
-          <dd>{{ checkin.article.article_title }}</dd>
-          <dt>{% trans "Journal title" %}</dt>
-          <dd>{{ checkin.article.journal_title }}</dd>
-          <dt>{% trans "Issue label" %}:</dt>
-          <dd>{{ checkin.article.issue_label }}</dd>
-        </dl>
+      <div class="span6">
+        <div class="well">
+          <h4>{% trans "Article Information" %}:</h4>
+          <dl class="dl-horizontal">
+            <dt>{% trans "Title" %}</dt>
+            <dd>{{ checkin.article.article_title }}</dd>
+            <dt>{% trans "Journal title" %}</dt>
+            <dd>{{ checkin.article.journal_title }}</dd>
+            <dt>{% trans "Issue label" %}:</dt>
+            <dd>{{ checkin.article.issue_label }}</dd>
+          </dl>
+        </div>
+
+        {% include "articletrack/includes/checkin_status_notice_block.html" %}
+
       </div>
 
       <div class="span6 well">
@@ -34,17 +39,15 @@
               <i class='icon-eye-close'></i>
             {% elif checkin.status == 'accepted' %}
               <i class='icon-ok-circle'></i>
+            {% elif checkin.status == 'checkout_scheduled' %}
+              <i class='icon-time'></i>
+            {% elif checkin.status == 'checkout_confirmed' %}
+              <i class='icon-ok'></i>
             {% else %}
               <i class='icon-question-sign'></i>
             {% endif %}
             {{ checkin.get_status_display }}
           </dd>
-          {% if checkin.status == 'accepted' and checkin.checked_out %}
-            <dd>
-              <dt>{% trans "Checked out" %}</dt>
-              <dd><i class='icon-ok-circle'></i></dd>
-            </dd>
-          {% endif %}
           <dt>{% trans "Package name" %}:</dt>
           <dd>{{ checkin.package_name }}</dd>
           <dt>{% trans "Updated at" %}:</dt>
@@ -53,43 +56,64 @@
           {% if checkin.submitted_by %}
             <dd>
             {% with checkin.submitted_by as user %}
-              {% include "articletrack/includes/gravatar_tooltip.html" %}  
+              {% include "articletrack/includes/gravatar_tooltip.html" %}
             {% endwith %}
             </dd>
           {% else %}
             <dd>--</dd>
           {% endif %}
 
-          {% if checkin.status == 'review' or checkin.status == 'accepted' %}
+          {% if checkin.is_level1_reviewed or  checkin.is_level2_reviewed or checkin.is_accepted or checkin.is_rejected or checkin.is_scheduled_to_checkout or checkin.is_checked_out %}
 
             {%if checkin.reviewed_by %}
+              <dt style="text-align: left;"><em>{% trans "Editorial review" %}:</em></dt>
+              <dd>&nbsp;</dd>
               <dt>{% trans "Reviewed by" %}:</dt>
-              <dd>{{ checkin.reviewed_by.get_full_name|default:checkin.reviewed_by }}</dd>
+              <dd>
+                {% with checkin.reviewed_by as user %}
+                  {% include "articletrack/includes/gravatar_tooltip.html" %}
+                {% endwith %}
+              </dd>
               <dt>{% trans "Reviewed at" %}:</dt>
               <dd>{{ checkin.reviewed_at|date:"d/m/Y - H:i" }}</dd>
             {% endif %}
 
             {%if checkin.scielo_reviewed_by %}
-              <dt style="text-align: left;"><em>SciELO review:</em></dt>
+              <dt style="text-align: left;"><em>{% trans "SciELO review" %}:</em></dt>
               <dd>&nbsp;</dd>
               <dt>{% trans "Reviewed by" %}:</dt>
-              <dd>{{ checkin.scielo_reviewed_by.get_full_name|default:checkin.scielo_reviewed_by }}</dd>
+              <dd>
+                {% with checkin.scielo_reviewed_by as user %}
+                  {% include "articletrack/includes/gravatar_tooltip.html" %}
+                {% endwith %}
+              </dd>
               <dt>{% trans "Reviewed at" %}:</dt>
               <dd>{{ checkin.scielo_reviewed_at|date:"d/m/Y - H:i" }}</dd>
             {% endif %}
 
           {% endif %}
 
-          {% if checkin.is_accepted %}
+          {% if checkin.is_accepted or checkin.is_scheduled_to_checkout or checkin.is_checked_out  %}
+              <dt style="text-align: left;"><em>{% trans "Acceptance info" %}:</em></dt>
+              <dd>&nbsp;</dd>
               <dt>{% trans "Accepted by" %}:</dt>
-              <dd>{{ checkin.accepted_by.get_full_name|default:checkin.accepted_by }}</dd>
-              <dt>{% trans "Acccepted at" %}:</dt>
+              <dd>
+                {% with checkin.accepted_by as user %}
+                  {% include "articletrack/includes/gravatar_tooltip.html" %}
+                {% endwith %}
+              </dd>
+              <dt>{% trans "Accepted at" %}:</dt>
               <dd>{{ checkin.accepted_at|date:"d/m/Y - H:i" }}</dd>
 
           {% elif checkin.is_rejected %}
-
+              <dt style="text-align: left;"><em>{% trans "Rejection info" %}:</em></dt>
+              <dd>&nbsp;</dd>
               <dt>{% trans "Rejected by" %}:</dt>
-              <dd>{{ checkin.rejected_by.get_full_name|default:checkin.rejected_by }}</dd>
+              <dd>
+                {% with checkin.rejected_by as user %}
+                  {% include "articletrack/includes/gravatar_tooltip.html" %}
+                {% endwith %}
+              </dd>
               <dt>{% trans "Rejected at" %}:</dt>
               <dd>{{ checkin.rejected_at|date:"d/m/Y - H:i" }}</dd>
               <dt>{% trans "Rejected reason" %}:</dt>
@@ -108,6 +132,7 @@
 
         </dl>
       </div>
+
     </div>
 
   </div>

--- a/scielomanager/articletrack/templates/articletrack/includes/checkin_status_notice_block.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/checkin_status_notice_block.html
@@ -1,64 +1,72 @@
 {% load i18n %}
-{% if checkin.is_rejected %}
+<div class="row-fluid show-grid">
+  <div class="span12">
 
-  <div class="row-fluid show-grid">
-    <div class="span12">
+    {% if checkin.is_rejected %}
+
       <div class="alert alert-error alert-block">
         <h4><i class="icon-warning-sign"></i> {% trans "REJECTED" %}:</h4>
         <p>
-          {% trans "This checkin was rejected by" %} 
+          {% trans "This checkin was rejected by" %}
           {% with checkin.rejected_by as user %}
-            {% include "articletrack/includes/gravatar_tooltip.html" %}  
-          {% endwith %} 
+            {% include "articletrack/includes/gravatar_tooltip.html" %}
+          {% endwith %}
           {% trans "at" %} {{ checkin.rejected_at|date:"d/m/Y - H:i" }}
         </p>
       </div>
-    </div>
-  </div>
 
-{% elif checkin.is_accepted %}
+    {% elif checkin.is_accepted %}
 
-  <div class="row-fluid show-grid">
-    <div class="span12">
       <div class="alert alert-success alert-block">
         <h4><i class="icon-ok-circle"></i> {% trans "ACCEPTED" %}:</h4>
         <p>
-          {% trans "This checkin is accepted by" %} 
+          {% trans "This checkin is accepted by" %}
           {% with checkin.accepted_by as user %}
-            {% include "articletrack/includes/gravatar_tooltip.html" %}  
-          {% endwith %} 
+            {% include "articletrack/includes/gravatar_tooltip.html" %}
+          {% endwith %}
           {% trans "at" %} {{ checkin.accepted_at|date:"d/m/Y - H:i" }}
         </p>
       </div>
-    </div>
-  </div>
 
-{% elif checkin.is_expirable %}
+    {% elif checkin.is_scheduled_to_checkout %}
 
-    <div class="row-fluid show-grid">
-    <div class="span12">
+      <div class="alert alert-success alert-block">
+        <h4><i class="icon-time"></i> {% trans "SCHEDULED TO CHECKOUT" %}:</h4>
+        <p>
+          {% trans "This checkin is scheduled to checkout and it will be processed soon" %}
+        </p>
+      </div>
+
+    {% elif checkin.is_checked_out %}
+
+      <div class="alert alert-success alert-block">
+        <h4><i class="icon-ok"></i> {% trans "CHECKED-OUT" %}:</h4>
+        <p>
+          {% trans "This checkin was checked-out and it will be available online soon" %}
+        </p>
+      </div>
+
+
+    {% elif checkin.is_expirable %}
+
       <div class="alert alert-error alert-block">
         <h4><i class="icon-ok-circle"></i> {% trans "THIS CHECKIN WILL EXPIRE TODAY" %}:</h4>
         <p>
-          {% trans "This checkin will expire at: " %} 
+          {% trans "This checkin will expire at: " %}
           {% trans "at" %} {{ checkin.expiration_at|date:"d/m/Y - H:i" }}
         </p>
         <p>
           {% trans "After that date, the checkin will be unreachable." %}
         </p>
       </div>
-    </div>
-  </div>
 
-{% elif checkin.status == "expired"  %}
+    {% elif checkin.status == "expired"  %}
 
-  <div class="row-fluid show-grid">
-    <div class="span12">
       <div class="alert alert-success alert-block">
         <h4><i class="icon-ok-circle"></i>{% trans "THIS CHECKIN IS EXPIRED!" %}</h4>
       </div>
-    </div>
+
+    {% endif %}
+
   </div>
-
-
-{% endif %}
+</div>

--- a/scielomanager/articletrack/templates/articletrack/notice_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/notice_detail.html
@@ -20,7 +20,7 @@
         <a href="{% url checkin_index %}"><i class="icon-chevron-left"></i> {% trans "List of Checkins" %}</a>
       </li>
       <li class="divider-vertical"></li>
-        {% if not checkin.is_accepted or checkin.can_be_send_to_checkout %}
+        {% if not checkin.is_accepted or checkin.can_be_scheduled_to_checkout %}
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               <strong>{% trans "Actions" %}:</strong>
@@ -63,7 +63,7 @@
                 {% if user.get_profile.can_review_l1_checkins and not checkin.is_level1_reviewed %}
                   <li>
                     <a href="{% url checkin_review checkin.pk 1 %}">
-                      <i class='icon-ok-circle'></i> <span class="label label-success">{% trans "Review" %}</span>
+                      <i class='icon-ok-circle'></i> <span class="label label-success">{% trans "Editorial Review" %}</span>
                     </a>
                   </li>
                 {% endif %}
@@ -85,11 +85,11 @@
                     <i class='icon-ok-circle'></i> <span class="label label-success">{% trans "Accept" %}</span>
                   </a>
                 </li>
-              {% elif checkin.can_be_send_to_checkout and user.get_profile.can_send_checkins_to_checkout %}
-                {# DO CHECKOUT #}
+              {% elif checkin.can_be_scheduled_to_checkout and user.get_profile.can_send_checkins_to_checkout %}
+                {# DO SEND TO CHECKOUT #}
                 <li>
                   <a href="{% url checkin_send_to_checkout checkin.pk %}">
-                    <i class='icon-ok-circle'></i> <span class="label label-success">{% trans "Checkout!" %}</span>
+                    <i class='icon-ok-circle'></i> <span class="label label-success">{% trans "Send to Checkout!" %}</span>
                   </a>
                 </li>
               {% endif %}
@@ -118,8 +118,6 @@
     </ul>
   </div>
 </div>
-
-{% include "articletrack/includes/checkin_status_notice_block.html" %}
 
 {% if not checkin.is_newest_checkin %}
   <div class="row-fluid show-grid">

--- a/scielomanager/articletrack/templates/email/checkin_sent_to_checkout.txt
+++ b/scielomanager/articletrack/templates/email/checkin_sent_to_checkout.txt
@@ -1,0 +1,5 @@
+Your article was sent to checkout, and will be processed soon.
+You will receive an email notifying when ready.
+<br/>
+<br/>
+Check: http://{{domain}}{% url notice_detail checkin.id %}

--- a/scielomanager/articletrack/templates/email/checkout_confirmed.txt
+++ b/scielomanager/articletrack/templates/email/checkout_confirmed.txt
@@ -1,0 +1,4 @@
+The process of Check-out of the article:{{ checkin.article }} has finished successfully, it will be available online soon.
+<br/>
+<br/>
+Check: http://{{domain}}{% url notice_detail checkin.id %}

--- a/scielomanager/articletrack/templates/email/comment_modify.txt
+++ b/scielomanager/articletrack/templates/email/comment_modify.txt
@@ -1,4 +1,4 @@
-Any comment of the ticket {{ticket.title}} <b>has been modified</b>.
+A comment of the ticket {{ticket.title}} <b>has been modified</b>.
 <br/>
 <br/>
 Check: http://{{domain}}{% url ticket_detail ticket.id %}

--- a/scielomanager/articletrack/templates/email/ticket_created.txt
+++ b/scielomanager/articletrack/templates/email/ticket_created.txt
@@ -1,4 +1,4 @@
-A ticket was created for checkin: {{checkin.package_name}}
+A ticket was created for article: {{ticket.article}}
 <br/>
 <br/>
 Check: http://{{domain}}{% url ticket_detail ticket.id %}

--- a/scielomanager/articletrack/tests/doubles.py
+++ b/scielomanager/articletrack/tests/doubles.py
@@ -59,6 +59,15 @@ class BalaioRPCDouble(BalaioRPC):
         return None
 
 
+class BalaioAPICallOKDouble(BalaioRPC):
+
+    def is_up(self):
+        return True
+
+    def call(self, method, args=()):
+        return True
+
+
 # packtools.stylechecker double
 
 

--- a/scielomanager/articletrack/tests/tests_tasks.py
+++ b/scielomanager/articletrack/tests/tests_tasks.py
@@ -10,7 +10,10 @@ from celery.task.base import Task
 from scielomanager.tasks import send_mail
 from . import modelfactories
 from . import doubles
-from articletrack.tasks import process_expirable_checkins, do_expires_checkin
+from articletrack.tasks import (
+    process_expirable_checkins, do_expires_checkin,
+    process_checkins_scheduled_to_checkout, do_proceed_to_checkout
+)
 from articletrack.models import Checkin
 
 
@@ -63,19 +66,42 @@ class TestCheckinExpirationTask(CeleryTestCaseBase, mocker.MockerTestCase):
         self.next_week_date = self.now + days_delta
 
     @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
-    def test_do_expires_checkin(self):
+    def test_do_expires_checkin_with_balaio_offline(self):
         """
         create a checkin, that expire today, then call do_expires_checkin()
+        With BalaioRPC offline, checkin.is_expirable == False, but status == 'expired'
         """
+        # with
         checkin = modelfactories.CheckinFactory(expiration_at=self.now)
 
-        # to avoid making a request will replace it with a double
         balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
         balaio()
         self.mocker.result(doubles.BalaioRPCDouble())
         self.mocker.replay()
-
+        # when
         result = do_expires_checkin.delay(checkin)
+        # then
+        checkin = Checkin.objects.get(pk=checkin.pk) # retrieve checkin from DB, to get updated checkin
+        self.assertTrue(result.successful())
+        self.assertFalse(checkin.is_expirable)
+        self.assertEqual('expired', checkin.status)
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_do_expires_checkin_with_balaio_online(self):
+        """
+        create a checkin, that expire today, then call do_expires_checkin()
+        """
+        # with
+        checkin = modelfactories.CheckinFactory(expiration_at=self.now)
+
+        balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
+        balaio()
+        self.mocker.result(doubles.BalaioAPICallOKDouble())
+        self.mocker.replay()
+        # when
+        result = do_expires_checkin.delay(checkin)
+        #then
+        checkin = Checkin.objects.get(pk=checkin.pk) # retrieve checkin from DB, to get updated checkin
         self.assertTrue(result.successful())
         self.assertFalse(checkin.is_expirable)
         self.assertEqual('expired', checkin.status)
@@ -103,3 +129,112 @@ class TestCheckinExpirationTask(CeleryTestCaseBase, mocker.MockerTestCase):
         for checkin in Checkin.objects.all():
             self.assertFalse(checkin.is_expirable)
             self.assertEqual('expired', checkin.status)
+
+class TestCheckinScheduledToCheckout(CeleryTestCaseBase, mocker.MockerTestCase):
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_do_proceed_to_checkout_with_balaio_offline(self):
+        """
+        create a checkin with status == "checkout_scheduled", ready to be checked-out, then call do_proceed_to_checkout()
+        with balaio API offline: the checkin will remain unmodified
+        """
+        # with
+        checkin = modelfactories.CheckinFactory(status="checkout_scheduled")
+        self.assertTrue(checkin.is_scheduled_to_checkout)
+        self.assertTrue(checkin.can_confirm_checkout)
+        self.assertFalse(checkin.is_checked_out)
+
+        balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
+        balaio()
+        self.mocker.result(doubles.BalaioRPCDouble())
+        self.mocker.replay()
+        # when
+        result = do_proceed_to_checkout.delay(checkin.pk)
+        # then
+        checkin = Checkin.objects.get(pk=checkin.pk) # retrieve checkin from DB, to get updated checkin
+        self.assertTrue(result.successful())
+        self.assertTrue(checkin.is_scheduled_to_checkout)
+        self.assertTrue(checkin.can_confirm_checkout)
+        self.assertFalse(checkin.is_checked_out)
+        self.assertEqual("checkout_scheduled", checkin.status)
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_do_proceed_to_checkout_with_balaio_online(self):
+        """
+        create a checkin with status == "checkout_scheduled", ready to be checked-out, then call do_proceed_to_checkout()
+        with balaio API online: the checkin will be checked-out successfully
+        """
+        # with
+        checkin = modelfactories.CheckinFactory(status="checkout_scheduled")
+        self.assertTrue(checkin.is_scheduled_to_checkout)
+        self.assertTrue(checkin.can_confirm_checkout)
+        self.assertFalse(checkin.is_checked_out)
+
+        balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
+        balaio()
+        self.mocker.result(doubles.BalaioAPICallOKDouble())
+        self.mocker.replay()
+        # when
+        result = do_proceed_to_checkout.delay(checkin.pk)
+        # then
+        checkin = Checkin.objects.get(pk=checkin.pk) # retrieve checkin from DB, to get updated checkin
+        self.assertTrue(result.successful())
+        self.assertFalse(checkin.is_scheduled_to_checkout)
+        self.assertFalse(checkin.can_confirm_checkout)
+        self.assertTrue(checkin.is_checked_out)
+        self.assertEqual("checkout_confirmed", checkin.status)
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_process_checkins_scheduled_to_checkout_with_balaio_offline(self):
+        """
+        create 10 checkins test, scheduled to checkout, then call process_checkins_scheduled_to_checkout()
+        with balaio API offline: the checkins will remain unmodified
+        """
+        # with
+        checkins = []
+
+        for x in xrange(0, 10):
+            checkin = modelfactories.CheckinFactory(status="checkout_scheduled")
+            checkins.append(checkin)
+
+        balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
+        for x in xrange(0, 10):
+            balaio()
+            self.mocker.result(doubles.BalaioRPCDouble())
+        self.mocker.replay()
+        # when
+        result = process_checkins_scheduled_to_checkout.delay()
+        # then
+        self.assertTrue(result.successful())
+        for checkin in Checkin.objects.all():
+            self.assertTrue(checkin.is_scheduled_to_checkout)
+            self.assertTrue(checkin.can_confirm_checkout)
+            self.assertFalse(checkin.is_checked_out)
+            self.assertEqual("checkout_scheduled", checkin.status)
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_process_checkins_scheduled_to_checkout_with_balaio_online(self):
+        """
+        create 10 checkins test, scheduled to checkout, then call process_checkins_scheduled_to_checkout()
+        with balaio API online: the checkins will be checked-out successfully
+        """
+        # with
+        checkins = []
+
+        for x in xrange(0, 10):
+            checkin = modelfactories.CheckinFactory(status="checkout_scheduled")
+            checkins.append(checkin)
+
+        balaio = self.mocker.replace('articletrack.balaio.BalaioRPC')
+        for x in xrange(0, 10):
+            balaio()
+            self.mocker.result(doubles.BalaioAPICallOKDouble())
+        self.mocker.replay()
+        # when
+        result = process_checkins_scheduled_to_checkout.delay()
+        # then
+        self.assertTrue(result.successful())
+        for checkin in Checkin.objects.all():
+            self.assertFalse(checkin.is_scheduled_to_checkout)
+            self.assertFalse(checkin.can_confirm_checkout)
+            self.assertTrue(checkin.is_checked_out)
+            self.assertEqual("checkout_confirmed", checkin.status)

--- a/scielomanager/articletrack/tests/tests_utils.py
+++ b/scielomanager/articletrack/tests/tests_utils.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+
+from django.core import mail
+from django.conf import settings
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from django_factory_boy import auth
+
+from articletrack.tests import modelfactories
+from articletrack import utils, models
+
+
+def generate_subject(action, subject=''):
+    subject_prefix = settings.EMAIL_SUBJECT_PREFIX
+    subject_suffix = utils.EMAIL_DATA_BY_ACTION[action]['subject_sufix']
+    return ' '.join([subject_prefix, subject, subject_suffix])
+
+
+class CheckinMessageTests(TestCase):
+    ACTIONS =  [
+        'checkin_reject',
+        'checkin_review',
+        'checkin_accept',
+        'checkin_send_to_pending',
+        'checkin_send_to_review',
+        'checkin_send_to_checkout',
+        'checkout_confirmed',
+    ]
+
+    def setUp(self):
+        self.submitter = auth.UserF(is_active=True)
+        self.checkin = modelfactories.CheckinFactory.create(submitted_by=self.submitter)
+        member1 = auth.UserF(is_active=True)
+        member2 = auth.UserF(is_active=True)
+        member3 = auth.UserF(is_active=True)
+        self.team = modelfactories.TeamFactory(name='test team')
+        self.team.join(member1)
+        self.team.join(member2)
+        self.team.join(member3)
+        self.team.join(self.submitter)
+        self.expected_recipients = [user.email for user in [member1, member2, member3, self.submitter, ]]
+        self.expected_recipients = list(set(self.expected_recipients))
+
+    def tearDown(self):
+        """
+        Restore the default values.
+        """
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_each_action(self):
+        email_count = 0
+        for action in self.ACTIONS:
+            email_count += 1
+            # when
+            result = utils.checkin_send_email_by_action(checkin=self.checkin, action=action)
+            # then
+            expected_subject = generate_subject(action=action, subject=self.checkin.package_name)
+
+            self.assertTrue(result)
+            self.assertEqual(len(mail.outbox), email_count)
+            new_email = mail.outbox[-1]
+            self.assertEqual(new_email.subject, expected_subject)
+            self.assertEqual(len(self.expected_recipients), len(new_email.to))
+            for recipient in self.expected_recipients:
+                self.assertIn(recipient, new_email.to)
+
+
+class TicketMessageTests(TestCase):
+    ACTIONS = [
+        'ticket_add',
+        'ticket_edit',
+        'ticket_close',
+    ]
+
+    def setUp(self):
+        self.submitter = auth.UserF(is_active=True)
+        self.checkin = modelfactories.CheckinFactory.create(submitted_by=self.submitter)
+        self.ticket = modelfactories.TicketFactory.create(article=self.checkin.article)
+        member1 = auth.UserF(is_active=True)
+        member2 = auth.UserF(is_active=True)
+        member3 = auth.UserF(is_active=True)
+        self.team = modelfactories.TeamFactory(name='test team')
+        self.team.join(member1)
+        self.team.join(member2)
+        self.team.join(member3)
+        self.team.join(self.submitter)
+        self.expected_recipients = [user.email for user in [member1, member2, member3, self.submitter, self.ticket.author]]
+        self.expected_recipients = list(set(self.expected_recipients))
+
+    def tearDown(self):
+        """
+        Restore the default values.
+        """
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_each_action(self):
+        email_count = 0
+        for action in self.ACTIONS:
+            email_count += 1
+            # when
+            result = utils.ticket_send_mail_by_action(ticket=self.ticket, action=action)
+            # then
+            expected_subject = generate_subject(action=action)
+
+            self.assertTrue(result)
+            self.assertEqual(len(mail.outbox), email_count)
+            new_email = mail.outbox[-1]
+            self.assertEqual(new_email.subject, expected_subject)
+            self.assertEqual(len(self.expected_recipients), len(new_email.to))
+            for recipient in self.expected_recipients:
+                self.assertIn(recipient, new_email.to)
+
+
+class CommentMessageTests(TestCase):
+    ACTIONS = [
+        'comment_created',
+        'comment_edit',
+    ]
+
+    def setUp(self):
+        self.submitter = auth.UserF(is_active=True)
+        self.checkin = modelfactories.CheckinFactory.create(submitted_by=self.submitter)
+        self.ticket = modelfactories.TicketFactory.create(article=self.checkin.article)
+        self.comment = modelfactories.CommentFactory.create(ticket=self.ticket)
+        member1 = auth.UserF(is_active=True)
+        member2 = auth.UserF(is_active=True)
+        member3 = auth.UserF(is_active=True)
+        self.team = modelfactories.TeamFactory(name='test team')
+        self.team.join(member1)
+        self.team.join(member2)
+        self.team.join(member3)
+        self.team.join(self.submitter)
+        self.expected_recipients = [user.email for user in [member1, member2, member3, self.submitter, self.ticket.author]]
+        self.expected_recipients = list(set(self.expected_recipients))
+
+    def tearDown(self):
+        """
+        Restore the default values.
+        """
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    def test_each_action(self):
+        email_count = 0
+        for action in self.ACTIONS:
+            email_count += 1
+            # when
+            result = utils.comment_send_mail_by_action(comment=self.comment, action=action)
+            # then
+            expected_subject = generate_subject(action=action)
+
+            self.assertTrue(result)
+            self.assertEqual(len(mail.outbox), email_count)
+            new_email = mail.outbox[-1]
+            self.assertEqual(new_email.subject, expected_subject)
+            self.assertEqual(len(self.expected_recipients), len(new_email.to))
+            for recipient in self.expected_recipients:
+                self.assertIn(recipient, new_email.to)

--- a/scielomanager/articletrack/utils.py
+++ b/scielomanager/articletrack/utils.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+import logging
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.template.loader import render_to_string
+
+from scielomanager import tasks
+
+EMAIL_DATA_BY_ACTION =  {
+    'checkin_reject': {
+        'subject_sufix': 'Package rejected',
+        'template_path': 'email/checkin_rejected.txt',
+    },
+    'checkin_review': {
+        'subject_sufix': 'Package reviewed',
+        'template_path': 'email/checkin_reviewed.txt',
+    },
+    'checkin_accept': {
+        'subject_sufix': 'Package accepted',
+        'template_path': 'email/checkin_accepted.txt',
+    },
+    'checkin_send_to_pending': {
+        'subject_sufix': 'Package send to pending',
+        'template_path': 'email/checkin_sent_to_pending.txt',
+    },
+    'checkin_send_to_review': {
+        'subject_sufix': 'Package sent to review',
+        'template_path': 'email/checkin_sent_to_review.txt',
+    },
+    'checkin_send_to_checkout': {
+        'subject_sufix': 'Package sent to checkout',
+        'template_path': 'email/checkin_sent_to_checkout.txt',
+    },
+    'checkout_confirmed': {
+        'subject_sufix': 'Package checkout confirmed',
+        'template_path': 'email/checkout_confirmed.txt',
+    },
+    'ticket_add': {
+        'subject_sufix': 'Ticket created',
+        'template_path': 'email/ticket_created.txt',
+    },
+    'ticket_edit': {
+        'subject_sufix': 'Ticket edited',
+        'template_path': 'email/ticket_modify.txt',
+    },
+    'ticket_close': {
+        'subject_sufix': 'Ticket closed',
+        'template_path': 'email/ticket_closed.txt',
+    },
+    'comment_created': {
+        'subject_sufix': 'New comment',
+        'template_path': 'email/comment_created.txt',
+    },
+    'comment_edit': {
+        'subject_sufix': 'Comment edited',
+        'template_path': 'email/comment_modify.txt',
+    },
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+class Message(object):
+    subject = ''
+    recipients = []
+    template_path = ''
+    body = ''
+
+    def __init__(self, action, subject='', recipients=[], template_path=None):
+        """
+        @param ``action``: key of EMAIL_DATA_BY_ACTION dict, will define some message presets
+        @param ``subject``: middle text of the message subject, prepended by:
+            settings.EMAIL_SUBJECT_PREFIX, appended by EMAIL_DATA_BY_ACTION[action]['subject_sufix']
+        @param ``recipients`` (optional), set the list of recipients of the message
+        @param ``template_path`` (optional), is the path of the templated used to render the message body,
+            if not provided, the template defined in EMAIL_DATA_BY_ACTION[action]['template_path'] will be used.
+        """
+        if not EMAIL_DATA_BY_ACTION.has_key(action):
+            raise ValueError("This action: %s is not available. Please use one of this: %s " % (action, EMAIL_DATA_BY_ACTION.keys()))
+
+        subject_sequence = [
+            settings.EMAIL_SUBJECT_PREFIX,
+            subject,
+            EMAIL_DATA_BY_ACTION[action]['subject_sufix'],
+        ]
+        self.subject = ' '.join(subject_sequence)
+        self.recipients = recipients
+
+        if template_path:
+            self.template_path = template_path
+        else:
+            self.template_path = EMAIL_DATA_BY_ACTION[action]['template_path']
+
+    def render_body(self, context=None):
+        """
+        render to string the body content.
+        Will include a default context, and also the @param context dict.
+        The result will be in self.body
+        """
+        domain = Site.objects.get_current().domain
+        default_context = {
+            'domain': domain,
+        }
+        if context:
+            context.update(default_context)
+        else:
+            context = default_context
+
+        self.body = render_to_string(self.template_path, context)
+
+
+    def set_recipients(self, *args, **kwargs):
+        """
+        Implement this method to update the recipients list, based in args and kwargs data.
+        """
+        raise NotImplementedError("Please Implement this method")
+
+    def send_mail(self):
+        """
+        if self.recipients is not empty, will call task.send_mail
+        """
+        if self.recipients:
+            return tasks.send_mail.delay(self.subject, self.body, self.recipients)
+        else:
+            logger.info("[Message.send_mail] Can't send a message without recipients, did you call 'set_recipients(...)'?")
+
+
+class CheckinMessage(Message):
+
+    def set_recipients(self, checkin):
+        """
+        Set the list of emails that will receive the message.
+        In case of checkins actions, the recipients will be the members of the team that include the user: checkin.submitted_by
+        and the submitter (checkin.submitted_by).
+        """
+        if checkin.team_members:
+            send_to = set([member.email for member in checkin.team_members])
+            # the submitter already belong to a related team
+            self.recipients = list(send_to)
+        else:
+            logger.info("[CheckinMessage.set_recipients] Can't prepare a message, checkin.team_members is empty. Checkin pk == %s" % checkin.pk)
+
+
+class TicketMessage(Message):
+
+    def set_recipients(self, ticket):
+        """
+        Set the list of emails that will receive the message.
+        In case of tickets or comments, the recipients will be:
+        the each member of a team, of each checkin related with the ticket,
+        and the submitter (checkin.submitted_by, already belong to a team) of each checkin,
+        and the author to the ticket related.
+        """
+        send_to = set([ticket.author.email, ])
+        for checkin in ticket.article.checkins.all():
+            # the submitter already belong to a related team
+            if checkin.team_members:
+                send_to.update([member.email for member in checkin.team_members])
+            else:
+                logger.info("[TicketMessage.set_recipients] Can't prepare a message, checkin.team_members is empty. Checkin pk == %s" % checkin.pk)
+        self.recipients = list(send_to)
+
+
+def checkin_send_email_by_action(checkin, action):
+
+    message = CheckinMessage(action=action, subject=checkin.package_name)
+    message.set_recipients(checkin)
+    extra_context = {'checkin': checkin, }
+    if checkin.rejected_cause:
+        extra_context['reason'] = checkin.rejected_cause
+    message.render_body(extra_context)
+    return message.send_mail()
+
+def ticket_send_mail_by_action(ticket, action):
+
+    message = TicketMessage(action=action)
+    message.set_recipients(ticket)
+    extra_context = {'ticket': ticket,}
+    message.render_body(extra_context)
+    return message.send_mail()
+
+def comment_send_mail_by_action(comment, action):
+
+    ticket = comment.ticket
+    message = TicketMessage(action=action)
+    message.set_recipients(ticket)
+    extra_context = {'ticket': ticket, 'comment': comment, }
+    message.render_body(extra_context)
+    return message.send_mail()

--- a/scielomanager/journalmanager/templatetags/user_avatar.py
+++ b/scielomanager/journalmanager/templatetags/user_avatar.py
@@ -38,15 +38,17 @@ def user_avatar_url(user, size):
         size = int(size)
     else:
         return '' # unknow size, no photo
-
-    user_gravatar_id = user.email
-
-    if user_gravatar_id:
-        params = urllib.urlencode({'s': size, 'd': 'mm'})
-        gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
-        avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_gravatar_id, params)
-        return avartar_url
-    else:
+    try:
+        user_gravatar_id = user.email
+    except AttributeError: # possible user is None
         return ''
+    else:
+        if user_gravatar_id:
+            params = urllib.urlencode({'s': size, 'd': 'mm'})
+            gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
+            avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_gravatar_id, params)
+            return avartar_url
+        else:
+            return ''
 
 register.simple_tag(user_avatar_url)

--- a/scielomanager/scielomanager/celery.py
+++ b/scielomanager/scielomanager/celery.py
@@ -21,12 +21,19 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 # Schedule:
 # http://celery.readthedocs.org/en/latest/userguide/periodic-tasks.html#crontab-schedules
 from celery.schedules import crontab
+from datetime import timedelta
+
 CELERYBEAT_SCHEDULE = {
     'checkin-expire-daily': {
         'task': 'articletrack.tasks.process_expirable_checkins',
         'schedule': crontab(minute=0, hour=0),
         'args': ()
     },
+    'process-checkins-scheduled-to-checkout-hourly': {
+        'task': 'articletrack.tasks.process_checkins_scheduled_to_checkout',
+        'schedule': timedelta(hours=1),
+        'args': ()
+    }
 }
 app.conf.update(
     CELERYBEAT_SCHEDULE=CELERYBEAT_SCHEDULE,


### PR DESCRIPTION
FIXES: #669
##### models.Checkin:
- removido campo: `checked_out`
- adiciono metodos e properties: `is_scheduled_to_checkout`,
  `is_checked_out`, `can_be_scheduled_to_checkout` e
  `can_confirm_checkout`
##### tasks:

adiciono tasks:
- `do_proceed_to_checkout`: que faz a conexão com balaioAPI, e se tiver sucesso, modifica o estado do checkin e envia emials.
- `process_checkins_scheduled_to_checkout`: pega todos os checkins agendados para fazer checkout e invoca a task: `do_proceed_to_checkout`
##### utils:
- `EMAIL_DATA_BY_ACTION`: setup para envio de msg para os checkins, tickets, e comments.
- `checkin_send_email_by_action`, `ticket_send_mail_by_action` e `comment_send_mail_by_action` preparam a msg e invocam a task para envio de emails.
##### views:
- `checkin_send_to_checkout`: agora não usa mas a  API do balaio, só muda o estado do checkin com: `checkin.do_schedule_to_checkout(request.user)`
- A lógica de envio de emails, agora usa as funções definidas no _utils.py_
