### PR TITLE
integração de auditoria nos forms #962

### DIFF
--- a/scielomanager/audit_log/admin.py
+++ b/scielomanager/audit_log/admin.py
@@ -2,8 +2,22 @@ from django.contrib import admin
 from audit_log.models import AuditLogEntry, AuditLogEntryPermission
 
 
+
 class AuditLogEntryAdmin(admin.ModelAdmin):
-    list_display = ['action_time', 'user', 'action_flag', 'object_repr', \
+
+    def get_action_flag(self, obj):
+        if obj.action_flag == 1: # additon
+            return "<span style='color: green;'>ADDED</span>"
+        elif obj.action_flag == 2: # change
+            return "<span style='color: orange;'>CHANGED</span>"
+        else:
+            return "<span style='color: red;'>DELETED</span>"
+    get_action_flag.short_description = 'Action'
+    get_action_flag.allow_tags = True
+    get_action_flag.admin_order_field = 'action_flag'
+
+
+    list_display = ['action_time', 'user', 'get_action_flag', 'object_repr', \
                     'content_type', 'object_id', 'change_message']
     readonly_fields = ['action_time', 'user', 'action_flag', 'object_repr', \
                        'content_type', 'object_id', 'change_message', \

--- a/scielomanager/audit_log/tests/tests_helpers.py
+++ b/scielomanager/audit_log/tests/tests_helpers.py
@@ -194,13 +194,12 @@ class AuditLogFromJournalFormTests(WebTest):
             'is_indexed_aehci',
         ]
 
-        expected_change_message = u'Changed fields: %s.' % get_text_list(fields_edited, 'and')
-        self.assertEqual(log_entry.change_message, expected_change_message)
-
         self.assertEqual(log_entry.new_values.keys(), [u'form_data', u'formsets_data'])
-        # all edited fields are in "new_values"-dict
         for field_edited in fields_edited:
+            # all edited fields are in "new_values"-dict
             self.assertIn(field_edited, log_entry.new_values['form_data'].keys())
+            # all edited fields are in the "change message" field
+            self.assertIn(field_edited, log_entry.change_message)
 
         # compare form data and stored new_values data
         for k,v in log_entry.new_values['form_data'].iteritems():

--- a/scielomanager/editorialmanager/views.py
+++ b/scielomanager/editorialmanager/views.py
@@ -15,6 +15,8 @@ from journalmanager.models import Journal, JournalMission, Issue
 from journalmanager.forms import RestrictedJournalForm, JournalMissionForm
 
 from scielomanager.tools import get_paginated
+from audit_log import helpers
+
 from . import forms
 from . import models
 
@@ -61,6 +63,9 @@ def journal_detail(request, journal_id):
 @login_required
 @user_passes_test(_user_has_access, login_url=settings.AUTHZ_REDIRECT_URL)
 def edit_journal(request, journal_id):
+    """
+    Handles only existing journals
+    """
     user_profile = request.user.get_profile()
     if request.user.is_superuser or user_profile.is_librarian:
         # redirect to full edit view:
@@ -68,21 +73,30 @@ def edit_journal(request, journal_id):
 
     journal = _get_journal_or_404_by_user_access(request.user, journal_id)
 
-    if journal_id is None:
-        journal = Journal()
-
     JournalMissionFormSet = inlineformset_factory(Journal, JournalMission, form=JournalMissionForm, extra=1, can_delete=True)
 
     if request.method == "POST":
         journalform = RestrictedJournalForm(request.POST, request.FILES, instance=journal, prefix='journal')
         missionformset = JournalMissionFormSet(request.POST, instance=journal, prefix='mission')
 
+        # this view only handle existing journals, so always exist previous values.
+        audit_old_values = helpers.collect_old_values(journal, journalform, [missionformset,])
+
         if journalform.is_valid() and missionformset.is_valid():
             journal = journalform.save()
             missionformset.save()
 
-            messages.success(request, _('Journal updated successfully.'))
+            audit_data = {
+                'user': request.user,
+                'obj': journal,
+                'message': helpers.construct_change_message(journalform, [missionformset, ]),
+                'old_values': audit_old_values,
+                'new_values': helpers.collect_new_values(journalform, [missionformset, ]),
+            }
+            # this view only handle existing journals, so always log changes.
+            helpers.log_change(**audit_data)
 
+            messages.success(request, _('Journal updated successfully.'))
             return HttpResponseRedirect(reverse('editorial.index'))
         else:
             messages.error(request, _('Check mandatory fields.'))
@@ -112,6 +126,10 @@ def board(request, journal_id):
 @login_required
 @permission_required('editorialmanager.change_editorialmember', login_url=settings.AUTHZ_REDIRECT_URL)
 def edit_board_member(request, journal_id, member_id):
+    """
+    Handles only existing editorial board member
+    """
+
     if request.is_ajax():
         template_name = 'board/board_member_edit_form.html'
     else:
@@ -133,8 +151,22 @@ def edit_board_member(request, journal_id, member_id):
 
     if request.method == "POST":
         form = forms.EditorialMemberForm(request.POST, instance=board_member)
+        # this view only handle existing editorial board member, so always exist previous values.
+        audit_old_values = helpers.collect_old_values(board_member, form)
+
         if form.is_valid():
-            form.save()
+            saved_obj = form.save()
+
+            audit_data = {
+                'user': request.user,
+                'obj': saved_obj,
+                'message': helpers.construct_change_message(form),
+                'old_values': audit_old_values,
+                'new_values': helpers.collect_new_values(form),
+            }
+            # this view only handle existing editorial board member, so always log changes.
+            helpers.log_change(**audit_data)
+
             messages.success(request, _('Board Member updated successfully.'))
             return HttpResponseRedirect(board_url)
         else:
@@ -151,6 +183,9 @@ def edit_board_member(request, journal_id, member_id):
 @login_required
 @permission_required('editorialmanager.add_editorialmember', login_url=settings.AUTHZ_REDIRECT_URL)
 def add_board_member(request, journal_id, issue_id):
+    """
+    Handles only NEW editorial board member
+    """
     if request.is_ajax():
         template_name = 'board/board_member_edit_form.html'
     else:
@@ -188,7 +223,18 @@ def add_board_member(request, journal_id, issue_id):
             new_member = form.save(commit=False)
             new_member.board = board
             new_member.save()
-            messages.info(request, _('Board Member created successfully.'))
+
+            audit_data = {
+                'user': request.user,
+                'obj': new_member,
+                'message': helpers.construct_create_message(form),
+                'old_values': None,
+                'new_values': helpers.collect_new_values(form),
+            }
+            # this view only handle NEW editorial board member, so always log create.
+            helpers.log_create(**audit_data)
+
+            messages.success(request, _('Board Member created successfully.'))
             return HttpResponseRedirect(board_url)
         else:
             messages.error(request, _('Check mandatory fields.'))
@@ -222,7 +268,10 @@ def delete_board_member(request, journal_id, member_id):
         'board_url': board_url,
     }
     if request.method == "POST":
-        # record audit log
+        # save the audit log
+        audit_message = helpers.construct_delete_message(board_member)
+        helpers.log_delete(request.user, board_member, audit_message)
+        # delete member!
         board_member.delete()
         messages.success(request, _('Board Member DELETED successfully.'))
         return HttpResponseRedirect(board_url)

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -574,13 +574,14 @@ def add_journal(request, journal_id=None):
                     audit_data = {
                         'user': request.user,
                         'obj': saved_journal,
-                        'message': helpers.construct_change_message(journalform, [titleformset, missionformset,]),
                         'old_values': audit_old_values,
                         'new_values': helpers.collect_new_values(journalform, [titleformset, missionformset,]),
                     }
                     if is_new_journal:
+                        audit_data['message'] = helpers.construct_create_message(journalform, [titleformset, missionformset,])
                         helpers.log_create(**audit_data)
                     else:
+                        audit_data['message'] = helpers.construct_change_message(journalform, [titleformset, missionformset,])
                         helpers.log_change(**audit_data)
 
                     messages.info(request, MSG_FORM_SAVED)


### PR DESCRIPTION
Fixes: #962
- adiciono código para auditar as mudanças feitas pelos editores no journal, e no board.
- melhoras no admin de auditlog para identificar as ações (add, change, delete).
- adiciono `if formsets:` para o caso que não tem formsets.
- [fix] mensagem de auditoria no form do journal, era sempre de mudança.
- [fix] test quebrava por causa da menssagem quando era auditado um ADD
- mudança no conteudo do campo `change_message` de auditoria, agora lista só os nomes dos campos e não o conteúdo, para ver os novos valores consutlar o campo `new_values`
