### PR TITLE
Botões *clear* e *validate* perdem layout após clique em *help* #995

### DIFF
--- a/scielomanager/scielomanager/static/js/modal.js
+++ b/scielomanager/scielomanager/static/js/modal.js
@@ -3,8 +3,8 @@ $(function() {
   /* hack to reload ajax content, and avoid caching trap */
   $('.modal').on('hidden', function() { $(this).removeData(); })
   $('.modal').on('shown', function () {
-    $('input').addClass('span12');
-    $(".chzn-select").chosen({
+    $(this).find('input').addClass('span12');
+    $(this).find(".chzn-select").chosen({
       no_results_text: "{% trans 'No results found for' %}:",
       width: "100%",
     });


### PR DESCRIPTION
FIXES: #995

usava o selector de forma errada, capturando todos os `input`s e `.chzn-select`s do DOM, quando o correto é capturar somente os campos dentro do modal.
