### PR TITLE
Criar teste de CRUD para o **editorialboard** #974

### DIFF
--- a/scielomanager/audit_log/helpers.py
+++ b/scielomanager/audit_log/helpers.py
@@ -203,7 +203,6 @@ def collect_new_values(form, formsets=None, as_json_string=False):
         "formsets_data": [],
     }
 
-    new_values = []
     for field_name in get_auditable_fields(form):
         field_value = form.cleaned_data[field_name]
         result["form_data"][field_name] = field_serializer(field_serializer(field_value))

--- a/scielomanager/editorialmanager/templates/board/board_member_delete_data.html
+++ b/scielomanager/editorialmanager/templates/board/board_member_delete_data.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form action="{{ post_url|default:'' }}" method="POST" class="form-horizontal">
+<form id="member-form" action="{{ post_url|default:'' }}" method="POST" class="form-horizontal">
     {% csrf_token %}
     <div class="alert alert-error">
         <h4>{% trans "This operation cannot be undone" %}</h4>

--- a/scielomanager/editorialmanager/templates/board/board_member_edit_form.html
+++ b/scielomanager/editorialmanager/templates/board/board_member_edit_form.html
@@ -1,6 +1,6 @@
 {% load show_field i18n %}
 
-<form action="{{ post_url|default:'' }}" method="POST" class="form-horizontal">
+<form id="member-form" action="{{ post_url|default:'' }}" method="POST" class="form-horizontal">
     {% csrf_token %}
     {% for field in form %}
         {% show_field field %}

--- a/scielomanager/editorialmanager/tests/test_forms.py
+++ b/scielomanager/editorialmanager/tests/test_forms.py
@@ -1,10 +1,35 @@
-#coding: utf-8
+# coding: utf-8
 
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
 
 from journalmanager.tests import modelfactories
-from journalmanager.tests.tests_forms import _makePermission
+
+from . import modelfactories as editorial_modelfactories
+from editorialmanager.models import EditorialMember, EditorialBoard
+from audit_log.models import AuditLogEntry, ADDITION, CHANGE, DELETION
+
+
+def _makePermission(perm, model, app_label='editorialmanager'):
+    """
+    Retrieves a Permission according to the given model and app_label.
+    """
+    from django.contrib.contenttypes import models
+    from django.contrib.auth import models as auth_models
+
+    ct = models.ContentType.objects.get(model=model, app_label=app_label)
+    return auth_models.Permission.objects.get(codename=perm, content_type=ct)
+
+
+def _add_required_permission_to_group(group):
+    # required permissions
+    perm_add_editorialmember = _makePermission(perm='add_editorialmember', model='editorialmember')
+    perm_change_editorialmember = _makePermission(perm='change_editorialmember', model='editorialmember')
+    perm_delete_editorialmember = _makePermission(perm='delete_editorialmember', model='editorialmember')
+
+    group.permissions.add(perm_add_editorialmember)
+    group.permissions.add(perm_change_editorialmember)
+    group.permissions.add(perm_delete_editorialmember)
 
 
 class RestrictedJournalFormTests(WebTest):
@@ -73,8 +98,8 @@ class AddUserAsEditorFormTests(WebTest):
 
     def setUp(self):
 
-        perm1 = _makePermission(perm='list_editor_journal', model='journal')
-        perm2 = _makePermission(perm='change_editor', model='journal')
+        perm1 = _makePermission(perm='list_editor_journal', model='journal', app_label='journalmanager')
+        perm2 = _makePermission(perm='change_editor', model='journal', app_label='journalmanager')
 
         #create a group 'Librarian'
         group = modelfactories.GroupFactory(name="Librarian")
@@ -116,9 +141,372 @@ class AddUserAsEditorFormTests(WebTest):
         response.mustcontain('Successfully selected %s as editor of this Journal' % user_editor.get_full_name())
 
 
+class EditorialMemberFormAsEditorTests(WebTest):
+
+    def setUp(self):
+        # create a group 'Editors'
+        group = modelfactories.GroupFactory(name="Editors")
+        # create a user and set group 'Editors'
+        self.user = modelfactories.UserFactory(is_active=True)
+        self.user.groups.add(group)
+
+        self.collection = modelfactories.CollectionFactory.create()
+        self.collection.add_user(self.user, is_manager=False)
+        self.collection.make_default_to_user(self.user)
+
+        self.journal = modelfactories.JournalFactory.create()
+        self.journal.join(self.collection, self.user)
+
+        # set the user as editor of the journal
+        self.journal.editor = self.user
+
+        # create an issue
+        self.issue = modelfactories.IssueFactory.create()
+        self.issue.journal = self.journal
+        self.journal.save()
+        self.issue.save()
+
+        _add_required_permission_to_group(group)
+
+    def tearDown(self):
+        pass
+
+    def test_ADD_board_memeber_valid_POST_is_valid(self):
+        """
+        User of the group "Editors" successfully ADD a new board member
+        """
+        # with
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        response = self.app.get(reverse("editorial.board.add", args=[self.journal.id, self.issue.id]), user=self.user)
+        pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
+        # when
+        member_data = {
+            'role': role,
+            'first_name': 'first name',
+            'last_name': 'last name',
+            'email': 'email@example.com',
+            'institution': 'institution name',
+            'link_cv': 'http://scielo.org/php/index.php',
+            'state': 'SP',
+            'country': 'Brasil',
+        }
+        # when
+        form = response.forms['member-form']
+        form.set('role',  member_data['role'].pk)
+        form['first_name'] = member_data['first_name']
+        form['last_name'] = member_data['last_name']
+        form['email'] = member_data['email']
+        form['institution'] = member_data['institution']
+        form['link_cv'] = member_data['link_cv']
+        form['state'] = member_data['state']
+        form['country'] = member_data['country']
+
+        response = form.submit().follow()
+
+        # then
+        self.assertIn('Board Member created successfully.', response.body)
+        self.assertTemplateUsed(response, 'board/board_list.html')
+
+        self.assertIn(member_data['role'].name, response.body)
+        self.assertIn(member_data['first_name'], response.body)
+        self.assertIn(member_data['last_name'], response.body)
+        self.assertIn(member_data['email'], response.body)
+        self.assertIn(member_data['institution'], response.body)
+        # the link_cv is not displayed in the frontend
+        self.assertIn(member_data['state'], response.body)
+        self.assertIn(member_data['country'], response.body)
+
+        # check new member in DB
+        members = EditorialMember.objects.filter(
+            role=member_data['role'],
+            first_name=member_data['first_name'],
+            last_name=member_data['last_name'],
+            email=member_data['email'],
+            institution=member_data['institution'],
+            link_cv=member_data['link_cv'],
+            state=member_data['state'],
+            country=member_data['country'],
+        )
+        self.assertEqual(len(members), 1)
+        # check relations
+        self.assertIsNotNone(self.issue.editorialboard)
+        self.assertEqual(len(self.issue.editorialboard.editorialmember_set.all()), 1)
+        self.assertEqual(members[0].pk, self.issue.editorialboard.editorialmember_set.all()[0].pk)
+
+        # check audit log:
+        self.assertEqual(pre_submittion_audit_logs_count, 0)
+        audit_entries = AuditLogEntry.objects.all()
+        self.assertEqual(audit_entries.count(), 1)
+        entry = audit_entries[0]
+        self.assertEqual(entry.action_flag, ADDITION) # Flag correspond with ADDITION action
+        self.assertEqual(entry.content_type.model_class(), EditorialMember)
+        audited_obj = entry.get_audited_object()
+        self.assertEqual(audited_obj._meta.object_name, 'EditorialMember')
+        self.assertEqual(audited_obj.pk, members[0].pk)
+
+        self.assertIn(u'Added fields:', entry.change_message) # message starts with u'Added fields:'
+        for field_name in member_data.keys():
+            self.assertIn(field_name, entry.change_message)
+
+    def test_ADD_board_memeber_invalid_POST_is_invalid(self):
+        """
+        User of the group "Editors" UNsuccessfully ADD a new board member with a invalid email
+        """
+
+        # with
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        response = self.app.get(reverse("editorial.board.add", args=[self.journal.id, self.issue.id]), user=self.user)
+        pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
+        # when
+        member_data = {
+            'role': role,
+            'first_name': 'first name',
+            'last_name': 'last name',
+            'email': 'email@example.com',
+            'institution': 'institution name',
+            'link_cv': '@invalid_url/index.php',
+            'state': 'SP',
+            'country': 'Brasil',
+        }
+        # when
+        form = response.forms['member-form']
+        form.set('role',  member_data['role'].pk)
+        form['first_name'] = member_data['first_name']
+        form['last_name'] = member_data['last_name']
+        form['email'] = member_data['email']
+        form['institution'] = member_data['institution']
+        form['link_cv'] = member_data['link_cv']
+        form['state'] = member_data['state']
+        form['country'] = member_data['country']
+
+        response = form.submit()
+
+        # check output
+        self.assertTemplateUsed(response, 'board/board_member_edit_form.html')
+        self.assertFalse(response.context['form'].is_valid())
+        expected_errors = {'link_cv': [u'Enter a valid URL.']}
+        self.assertEqual(response.context['form'].errors, expected_errors)
+        self.assertIn('Check mandatory fields.', response.body)
+        # expected extra context data
+        expected_post_url = reverse('editorial.board.add', args=[self.journal.pk, self.issue.pk, ])
+        expected_board_url = reverse('editorial.board', args=[self.journal.pk, ])
+        self.assertEqual(response.context['post_url'], expected_post_url)
+        self.assertEqual(response.context['board_url'], expected_board_url)
+
+        # check relations: board created if none, but no members added
+        self.assertIsNotNone(self.issue.editorialboard)
+        self.assertEqual(len(self.issue.editorialboard.editorialmember_set.all()), 0)
+
+        # check audit logs: no logs generated
+        self.assertEqual(pre_submittion_audit_logs_count, 0)
+        self.assertEqual(AuditLogEntry.objects.all().count(), 0)
 
 
+    def test_EDIT_board_memeber_valid_POST_is_valid(self):
+        """
+        User of the group "Editors" successfully EDIT a board member
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        member_data_update = {
+            'role': role,
+            'first_name': 'Nombre',
+            'last_name': 'Apellido',
+            'email': 'nombre.apellido@fing.edu.uy',
+            'institution': 'Universidad de la Republica - Facultad de Ingenieria',
+            'link_cv': 'http://scielo.org.uy/',
+            'state': 'Montevideo',
+            'country': 'Uruguay',
+        }
+        response = self.app.get(reverse("editorial.board.edit", args=[self.journal.id, member.id]), user=self.user)
+        pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
+
+        # when
+        form = response.forms['member-form']
+        form.set('role',  member_data_update['role'].pk)
+        form['first_name'] = member_data_update['first_name']
+        form['last_name'] = member_data_update['last_name']
+        form['email'] = member_data_update['email']
+        form['institution'] = member_data_update['institution']
+        form['link_cv'] = member_data_update['link_cv']
+        form['state'] = member_data_update['state']
+        form['country'] = member_data_update['country']
+
+        response = form.submit().follow()
+        # then
+
+        # check frontend
+        self.assertIn('Board Member updated successfully.', response.body)
+        self.assertTemplateUsed(response, 'board/board_list.html')
+        self.assertIn(member_data_update['role'].name, response.body)
+        self.assertIn(member_data_update['first_name'], response.body)
+        self.assertIn(member_data_update['last_name'], response.body)
+        self.assertIn(member_data_update['email'], response.body)
+        self.assertIn(member_data_update['institution'], response.body)
+        # the link_cv is not displayed in the frontend
+        self.assertIn(member_data_update['state'], response.body)
+        self.assertIn(member_data_update['country'], response.body)
+
+        # check data from db
+        member_from_db = EditorialMember.objects.get(pk=member.pk)
+        self.assertEqual(member_from_db.role, member_data_update['role'])
+        self.assertEqual(member_from_db.first_name, member_data_update['first_name'])
+        self.assertEqual(member_from_db.last_name, member_data_update['last_name'])
+        self.assertEqual(member_from_db.email, member_data_update['email'])
+        self.assertEqual(member_from_db.institution, member_data_update['institution'])
+        self.assertEqual(member_from_db.link_cv, member_data_update['link_cv'])
+        self.assertEqual(member_from_db.state, member_data_update['state'])
+        self.assertEqual(member_from_db.country, member_data_update['country'])
+
+        # check relations
+        self.assertIsNotNone(self.issue.editorialboard)
+        self.assertEqual(len(self.issue.editorialboard.editorialmember_set.all()), 1)
+        self.assertEqual(member_from_db.pk, self.issue.editorialboard.editorialmember_set.all()[0].pk)
+
+        # check audit log:
+        self.assertEqual(pre_submittion_audit_logs_count, 0)
+        audit_entries = AuditLogEntry.objects.all()
+        self.assertEqual(audit_entries.count(), 1)
+        entry = audit_entries[0]
+        self.assertEqual(entry.action_flag, CHANGE) # Flag correspond with CHANGE action
+        self.assertEqual(entry.content_type.model_class(), EditorialMember)
+        audited_obj = entry.get_audited_object()
+        self.assertEqual(audited_obj._meta.object_name, 'EditorialMember')
+        self.assertEqual(audited_obj.pk, member_from_db.pk)
+
+        self.assertIn( u'Changed fields:', entry.change_message) # message starts with u'Changed fields:'
+        for field_name in member_data_update.keys():
+            self.assertIn(field_name, entry.change_message)
+
+    def test_EDIT_board_memeber_invalid_POST_is_invalid(self):
+        """
+        User of the group "Editors" UNsuccessfully EDIT a board member with a invalid email
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        member_data_update = {
+            'role': role,
+            'first_name': 'Nombre',
+            'last_name': 'Apellido',
+            'email': 'nombre.apellido@', # invalid email
+            'institution': 'Universidad de la Republica - Facultad de Ingenieria',
+            'link_cv': 'http://scielo.org.uy/',
+            'state': 'Montevideo',
+            'country': 'Uruguay',
+        }
+        response = self.app.get(reverse("editorial.board.edit", args=[self.journal.id, member.id]), user=self.user)
+        pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
+
+        # when
+        form = response.forms['member-form']
+        form.set('role',  member_data_update['role'].pk)
+        form['first_name'] = member_data_update['first_name']
+        form['last_name'] = member_data_update['last_name']
+        form['email'] = member_data_update['email']
+        form['institution'] = member_data_update['institution']
+        form['link_cv'] = member_data_update['link_cv']
+        form['state'] = member_data_update['state']
+        form['country'] = member_data_update['country']
+
+        response = form.submit()
+
+        # then
+        # check output
+        self.assertTemplateUsed(response, 'board/board_member_edit_form.html')
+        self.assertFalse(response.context['form'].is_valid())
+        expected_errors = {'email': [u'Enter a valid e-mail address.']}
+        self.assertEqual(response.context['form'].errors, expected_errors)
+        self.assertIn('Check mandatory fields.', response.body)
+
+        # expected extra context data
+        expected_post_url = reverse("editorial.board.edit", args=[self.journal.id, member.id])
+        expected_board_url = reverse('editorial.board', args=[self.journal.pk, ])
+        self.assertEqual(response.context['post_url'], expected_post_url)
+        self.assertEqual(response.context['board_url'], expected_board_url)
+        self.assertEqual(response.context['board_member'].pk, member.pk)
+
+        # check relations: board remains the same, but no members were edited
+        self.assertIsNotNone(self.issue.editorialboard)
+        self.assertEqual(len(self.issue.editorialboard.editorialmember_set.all()), 1)
+        member_from_db = self.issue.editorialboard.editorialmember_set.all()[0]
+
+        self.assertEqual(member_from_db.role, member.role)
+        self.assertEqual(member_from_db.first_name, member.first_name)
+        self.assertEqual(member_from_db.last_name, member.last_name)
+        self.assertEqual(member_from_db.email, member.email)
+        self.assertEqual(member_from_db.institution, member.institution)
+        self.assertEqual(member_from_db.link_cv, member.link_cv)
+        self.assertEqual(member_from_db.state, member.state)
+        self.assertEqual(member_from_db.country, member.country)
+
+        # check audit logs: no logs generated
+        self.assertEqual(pre_submittion_audit_logs_count, 0)
+        self.assertEqual(AuditLogEntry.objects.all().count(), 0)
+
+    def test_DELETE_board_memeber_valid_POST_is_valid(self):
+        """
+        User of the group "Editors" successfully DELETE a board member
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        response = self.app.get(reverse("editorial.board.delete", args=[self.journal.id, member.id]), user=self.user)
+        form = response.forms['member-form']
+        pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
+
+        # when
+        response = form.submit().follow()
+
+        # then
+
+        # check frontend
+        self.assertIn('Board Member DELETED successfully.', response.body)
+        self.assertTemplateUsed(response, 'board/board_list.html')
+
+        # check that member was deleted from DB
+        # using .filter(pk=...) to receive a [emtpy] list, and avoid DoesNotExist exception
+        members_from_db = EditorialMember.objects.filter(pk=member.pk)
+        self.assertNotIn(member, members_from_db)
+
+        # check relations: board remains the same, but no members were edited
+        self.assertIsNotNone(self.issue.editorialboard)
+        self.assertNotIn(member, self.issue.editorialboard.editorialmember_set.all())
+        self.assertEqual(len(self.issue.editorialboard.editorialmember_set.all()), 0)
+
+        # check audit log:
+        self.assertEqual(pre_submittion_audit_logs_count, 0)
+        audit_entries = AuditLogEntry.objects.all()
+        self.assertEqual(audit_entries.count(), 1)
+        entry = audit_entries[0]
+        self.assertEqual(entry.action_flag, DELETION) # Flag correspond with DELETE action
+        self.assertEqual(entry.content_type.model_class(), EditorialMember)
+        audited_obj = entry.get_audited_object()
+        self.assertIsNone(audited_obj) # audited object (member) was deleted, so, no referece to it
+        expected_change_msg = u'Record DELETED (%s, pk: %s): %s' % (member.pk, member._meta.verbose_name, unicode(member))
+        self.assertEqual(entry.change_message, expected_change_msg)
 
 
+class EditorialMemberFormAsLibrarianTests(EditorialMemberFormAsEditorTests):
+    """
+    Excecute the same tests that an Editors (EditorialMemberFormAsEditorTests), the setUp is almost the same.
+    Only change is that the self.user is assigned as a member of "Librarian" group instead of "Editors" group.
+    """
+    def setUp(self):
+        super(EditorialMemberFormAsLibrarianTests, self).setUp()
+        # change user group to belong to Librarian group
+        self.user.groups.clear()
+        group = modelfactories.GroupFactory(name="Librarian")
+        self.user.groups.add(group)
+        self.user.save()
 
+        _add_required_permission_to_group(group)
 
+    def tearDown(self):
+        super(EditorialMemberFormAsLibrarianTests, self).tearDown()

--- a/scielomanager/editorialmanager/tests/test_pages.py
+++ b/scielomanager/editorialmanager/tests/test_pages.py
@@ -1,20 +1,27 @@
-#coding: utf-8
+# coding: utf-8
 
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
-
+from django.conf import settings
 from journalmanager.tests import modelfactories
+from . import modelfactories as editorial_modelfactories
+from .test_forms import _makePermission
+from editorialmanager.models import EditorialMember, EditorialBoard
 
 
-class IndexPageTests(WebTest):
+def _set_permission_to_group(perm, group):
+    perm_add_editorialmember = _makePermission(perm=perm, model='editorialmember')
+    group.permissions.add(perm_add_editorialmember)
+
+
+class PagesAsEditorTests(WebTest):
 
     def setUp(self):
-        #create a group 'Editors'
-        group = modelfactories.GroupFactory(name="Editors")
-
-        #create a user and set group 'Editors'
+        # create a group 'Editors'
+        self.group = modelfactories.GroupFactory(name="Editors")
+        # create a user and set group 'Editors'
         self.user = modelfactories.UserFactory(is_active=True)
-        self.user.groups.add(group)
+        self.user.groups.add(self.group)
 
         self.collection = modelfactories.CollectionFactory.create()
         self.collection.add_user(self.user, is_manager=False)
@@ -23,20 +30,223 @@ class IndexPageTests(WebTest):
         self.journal = modelfactories.JournalFactory.create()
         self.journal.join(self.collection, self.user)
 
-        #set the user as editor of the journal
+        # set the user as editor of the journal
         self.journal.editor = self.user
+
+        # create an issue
+        self.issue = modelfactories.IssueFactory.create()
+        self.issue.journal = self.journal
         self.journal.save()
+        self.issue.save()
 
-    def test_logged_editor_access_to_index_of_editorial_manager(self):
+    def tearDown(self):
+        pass
 
+    def test_logged_user_access_to_index(self):
+        """
+        User loggin and access 'editorial.index' page,
+        the result must show the journal who is editable by the logged user
+        """
+        # when
         response = self.app.get(reverse('editorial.index'), user=self.user)
-
+        # then
+        self.assertTrue(self.user.get_profile().is_editor or self.user.get_profile().is_librarian)
         self.assertTemplateUsed(response, 'journal/journal_list.html')
 
-    def test_logged_editor_access_to_index_and_see_your_journals(self):
+        journals_in_response = response.context['objects_journal']
+        self.assertIsNotNone(journals_in_response)
+        journals_in_response = journals_in_response.object_list
+        self.assertIn(self.journal, journals_in_response)
+        response.mustcontain(self.journal.title)
+        journal_detail_link_url = reverse("editorial.journal.detail", args=[self.journal.pk])
+        response.mustcontain(journal_detail_link_url)
 
-        response = self.app.get(reverse('editorial.index'), user=self.user)
-
+    def test_logged_user_access_to_journal_detail(self):
+        # when
+        response = self.app.get(reverse("editorial.journal.detail", args=[self.journal.pk]), user=self.user)
+        # then
+        self.assertTemplateUsed(response, 'journal/journal_detail.html')
+        journal_in_response = response.context['journal']
+        self.assertIsNotNone(journal_in_response)
         response.mustcontain(self.journal.title)
 
-        self.assertTemplateUsed(response, 'journal/journal_list.html')
+    def test_user_access_links_to_add_when_have_permissions(self):
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        add_url = reverse("editorial.board.add", args=[self.journal.id, self.issue.id])
+        board_url = reverse("editorial.board", args=[self.journal.pk])
+        # when
+        response = self.app.get(board_url, user=self.user)
+
+        # then
+
+        # have no link to ADD, EDIT or DELETE a board member
+        self.assertNotIn(add_url, response.body)
+        # when gain permission to ADD editorial member, the link is shown
+        _set_permission_to_group('add_editorialmember', self.group)
+        response = self.app.get(board_url, user=self.user)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(add_url, response.body)
+
+    def test_user_access_links_to_edit_when_have_permissions(self):
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        edit_url = reverse("editorial.board.edit", args=[self.journal.id, member.id])
+        board_url = reverse("editorial.board", args=[self.journal.pk])
+        # when
+        response = self.app.get(board_url, user=self.user)
+
+        # then
+        # have no link to ADD, EDIT or DELETE a board member
+        self.assertNotIn(edit_url, response.body)
+        # when gain permission to EDIT editorial member, the link is shown
+        _set_permission_to_group('change_editorialmember', self.group)
+        response = self.app.get(board_url, user=self.user)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(edit_url, response.body)
+
+    def test_user_access_links_to_delete_when_have_permissions(self):
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        delete_url = reverse("editorial.board.delete", args=[self.journal.id, member.id])
+        board_url = reverse("editorial.board", args=[self.journal.pk])
+        # when
+        response = self.app.get(reverse("editorial.board", args=[self.journal.pk]), user=self.user)
+
+        # then
+
+        # have no link to ADD, EDIT or DELETE a board member
+        self.assertNotIn(delete_url,response.body)
+
+        # when gain permission to DELETE editorial member, the link is shown
+        _set_permission_to_group('delete_editorialmember', self.group)
+        response = self.app.get(board_url, user=self.user)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(delete_url, response.body)
+
+    def test_unauthorized_user_access_to_add_member_page(self):
+        """
+        A user without permissions to EDIT board member, when try to access the *EDIT* page,
+        will be redirected to ``settings.AUTHZ_REDIRECT_URL``
+        """
+        # when
+        response = self.app.get(
+            reverse("editorial.board.add", args=[self.journal.id, self.issue.id]),
+            user=self.user,
+            expect_errors=True)
+        # then
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.AUTHZ_REDIRECT_URL, response.location)
+        self.assertTemplateUsed(response.follow(), 'accounts/unauthorized.html')
+
+    def test_authorized_user_access_to_add_member_page(self):
+        """
+        A user with permissions to ADD board member, when try to access the *ADD* page,
+        will see the correct page
+        """
+        # with
+        _set_permission_to_group('add_editorialmember', self.group)
+        # when
+        response = self.app.get(
+            reverse("editorial.board.add", args=[self.journal.id, self.issue.id]),
+            user=self.user)
+        # when
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'board/board_member_edit.html')
+
+    def test_unauthorized_user_access_to_edit_member_page(self):
+        """
+        A user without permissions to EDIT board member, when try to access the *EDIT* page,
+        will be redirected to ``settings.AUTHZ_REDIRECT_URL``
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        # when
+        response = self.app.get(
+            reverse("editorial.board.edit", args=[self.journal.id, member.id]),
+            user=self.user,
+            expect_errors=True)
+        # then
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.AUTHZ_REDIRECT_URL, response.location)
+        self.assertTemplateUsed(response.follow(), 'accounts/unauthorized.html')
+
+    def test_authorized_user_access_to_edit_member_page(self):
+        """
+        A user with permissions to EDIT board member, when try to access the *EDIT* page,
+        will see the correct page
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        _set_permission_to_group('change_editorialmember', self.group)
+        # when
+        response = self.app.get(
+            reverse("editorial.board.edit", args=[self.journal.id, member.id]),
+            user=self.user)
+        # when
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'board/board_member_edit.html')
+
+    def test_unauthorized_user_access_to_delete_member_page(self):
+        """
+        A user without permissions to DELETE board member, when try to access the *DELETE* page,
+        will be redirected to ``settings.AUTHZ_REDIRECT_URL``
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        # when
+        response = self.app.get(
+            reverse("editorial.board.delete", args=[self.journal.id, member.id]),
+            user=self.user,
+            expect_errors=True)
+        # then
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.AUTHZ_REDIRECT_URL, response.location)
+        self.assertTemplateUsed(response.follow(), 'accounts/unauthorized.html')
+
+    def test_authorized_user_access_to_delete_member_page(self):
+        """
+        A user with permissions to DELETE board member, when try to access the *DELETE* page,
+        will see the correct page
+        """
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        member.board = EditorialBoard.objects.create(issue=self.issue)
+        member.save()
+        _set_permission_to_group('delete_editorialmember', self.group)
+        # when
+        response = self.app.get(
+            reverse("editorial.board.delete", args=[self.journal.id, member.id]),
+            user=self.user)
+        # when
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'board/board_member_delete.html')
+
+
+class PagesAsLibrarianTests(PagesAsEditorTests):
+    """
+    Excecute the same tests that an Editors (PagesAsEditorTests), the setUp is almost the same.
+    Only change is that the self.user is assigned as a member of "Librarian" group instead of "Editors" group.
+    """
+    def setUp(self):
+        super(PagesAsLibrarianTests, self).setUp()
+        # change user group to belong to Librarian group
+        self.user.groups.clear()
+        self.group = modelfactories.GroupFactory(name="Librarian")
+        self.user.groups.add(self.group)
+        self.user.save()
+
+    def tearDown(self):
+        super(PagesAsLibrarianTests, self).tearDown()


### PR DESCRIPTION
Fixes: #974 
- removida a lista vacia, que não era utilizada
- [board_member_delete_data.html] adiciono atributo id no `<form>`, para facilitar nos test.
- [board_member_edit_data.html] adiciono atributo id no `<form>`, para facilitar nos test.
- adiciono varios tests de formularios e paginas, para usuarios no grupo **Editors** e **Librarian**
- adiciono código nos test para controlar que as mudanças nos forms são auditadas.
