### PR TITLE
FIX: Bug On-line. #1018

### DIFF
--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -434,7 +434,7 @@ def exclude_user_from_collection(request, user_id=None):
 
     if user_id:
         user = get_object_or_404(User, id=user_id)
-        
+
         collection.remove_user(user)
 
     return HttpResponseRedirect(reverse('user.index'))
@@ -829,7 +829,7 @@ def edit_issue(request, journal_id, issue_id=None):
 
         audit_old_values = helpers.collect_old_values(issue, form, [titleformset, ])
 
-        if form.is_valid():
+        if form.is_valid() and titleformset.is_valid():
             saved_issue = form.save(commit=False)
             saved_issue.journal = issue.journal
             saved_issue.save()
@@ -937,7 +937,7 @@ def add_issue(request, issue_type, journal_id, issue_id=None):
         add_form = get_issue_form_by_type(issue_type, request, journal, instance=issue)
         titleformset = IssueTitleFormSet(request.POST, instance=issue, prefix='title')
 
-        if add_form.is_valid():
+        if add_form.is_valid() and titleformset.is_valid():
             saved_issue = add_form.save(commit=False)
             saved_issue.journal = journal
             saved_issue.type = issue_type


### PR DESCRIPTION
Fixes: #1018

**tldr;** o erro aparece ao acessar informação do formset, quando o formset é inválido.

O erro: `AttributeError: 'IssueTitleFormFormSet' object has no attribute 'new_objects'` aparece no modulo `helpers.py` da app: audit_log,
mas isso acontece por causa que o formset é acessado para obter os dados auditáveis, mas o formset é inválido.
Como mostra (no fragmento do erro) os campos submetidos no POST, neste caso, os campos do formset estão incompletos:

``` json
{
...
"title-0-language": [""],
"title-MAX_NUM_FORMS": ["1000"],
"title-TOTAL_FORMS": ["1"],
"title-INITIAL_FORMS": ["0"],
"title-0-id": [""],
"title-0-title": ["La mexicanidad y el neoindianismo hoy"],
"title-0-issue": [""],
...
}
```

indicam que o campo `title` tem conteúdo, mas o campo: `language` está vazio, o que determina o formset como inválido.

agora foi adicinado o control necessário, e os tests na edição e criação de Issues.
