### PR TITLE
FIX: Corregir vazamento da funcionalidade de "Editorial Manager" #1021

### DIFF
--- a/scielomanager/editorialmanager/tests/test_forms.py
+++ b/scielomanager/editorialmanager/tests/test_forms.py
@@ -2,6 +2,7 @@
 
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
+from waffle import Flag
 
 from journalmanager.tests import modelfactories
 
@@ -35,6 +36,8 @@ def _add_required_permission_to_group(group):
 class RestrictedJournalFormTests(WebTest):
 
     def setUp(self):
+        # create waffle:
+        Flag.objects.create(name='editorialmanager', everyone=True)
         #create a group 'Editors'
         group = modelfactories.GroupFactory(name="Editors")
 
@@ -97,6 +100,8 @@ class RestrictedJournalFormTests(WebTest):
 class AddUserAsEditorFormTests(WebTest):
 
     def setUp(self):
+        # create waffle:
+        Flag.objects.create(name='editorialmanager', everyone=True)
 
         perm1 = _makePermission(perm='list_editor_journal', model='journal', app_label='journalmanager')
         perm2 = _makePermission(perm='change_editor', model='journal', app_label='journalmanager')
@@ -144,6 +149,8 @@ class AddUserAsEditorFormTests(WebTest):
 class EditorialMemberFormAsEditorTests(WebTest):
 
     def setUp(self):
+        # create waffle:
+        Flag.objects.create(name='editorialmanager', everyone=True)
         # create a group 'Editors'
         group = modelfactories.GroupFactory(name="Editors")
         # create a user and set group 'Editors'

--- a/scielomanager/editorialmanager/views.py
+++ b/scielomanager/editorialmanager/views.py
@@ -11,6 +11,8 @@ from django.template.context import RequestContext
 from django.forms.models import inlineformset_factory
 from django.contrib.auth.decorators import login_required, permission_required, user_passes_test
 
+from waffle.decorators import waffle_flag
+
 from journalmanager.models import Journal, JournalMission, Issue
 from journalmanager.forms import RestrictedJournalForm, JournalMissionForm
 
@@ -42,6 +44,7 @@ def _get_journal_or_404_by_user_access(user, journal_id):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @user_passes_test(_user_has_access, login_url=settings.AUTHZ_REDIRECT_URL)
 def index(request):
     journals = _get_journals_by_user_access(request.user)
@@ -54,6 +57,7 @@ def index(request):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @user_passes_test(_user_has_access, login_url=settings.AUTHZ_REDIRECT_URL)
 def journal_detail(request, journal_id):
     journal = _get_journal_or_404_by_user_access(request.user, journal_id)
@@ -64,6 +68,7 @@ def journal_detail(request, journal_id):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @user_passes_test(_user_has_access, login_url=settings.AUTHZ_REDIRECT_URL)
 def edit_journal(request, journal_id):
     """
@@ -115,6 +120,7 @@ def edit_journal(request, journal_id):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @user_passes_test(_user_has_access, login_url=settings.AUTHZ_REDIRECT_URL)
 def board(request, journal_id):
     journal = _get_journal_or_404_by_user_access(request.user, journal_id)
@@ -127,6 +133,7 @@ def board(request, journal_id):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @permission_required('editorialmanager.change_editorialmember', login_url=settings.AUTHZ_REDIRECT_URL)
 def edit_board_member(request, journal_id, member_id):
     """
@@ -184,6 +191,7 @@ def edit_board_member(request, journal_id, member_id):
 
 
 @login_required
+@waffle_flag('editorialmanager')
 @permission_required('editorialmanager.add_editorialmember', login_url=settings.AUTHZ_REDIRECT_URL)
 def add_board_member(request, journal_id, issue_id):
     """
@@ -250,6 +258,8 @@ def add_board_member(request, journal_id, issue_id):
     return render_to_response(template_name, context, context_instance=RequestContext(request))
 
 
+@login_required
+@waffle_flag('editorialmanager')
 @permission_required('editorialmanager.delete_editorialmember', login_url=settings.AUTHZ_REDIRECT_URL)
 def delete_board_member(request, journal_id, member_id):
     # check if user have correct access to view the journal:

--- a/scielomanager/journalmanager/tests/tests_pages.py
+++ b/scielomanager/journalmanager/tests/tests_pages.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
 from django_factory_boy import auth
+from waffle import Flag
 
 from journalmanager.tests import modelfactories
 from journalmanager.tests.tests_forms import _makePermission
@@ -328,6 +329,7 @@ class IndexPageTests(WebTest):
         self.assertTemplateUsed(response, 'journalmanager/home_journal.html')
 
     def test_logged_editor_user_access_to_list_journal(self):
+        Flag.objects.create(name='editorialmanager', everyone=True)
         editors_group = modelfactories.GroupFactory.create(name='Editors')
         perm = _makePermission(perm='list_editor_journal', model='journal', app_label='journalmanager')
         editors_group.permissions.add(perm)


### PR DESCRIPTION
Fixes: #1021
- adicionado o if com o waffle na view: `journalmanager.views.add_issue`
- modificado test para verificar que funciona o submit do form com o waffle ativo.
- adicionado test para verficiar que funciona o submit do form sem waffle criando issue mas sem board.
- adiciono `@waffle_flag` decorator para restringir acesso nessas views (`editorialmanager.views`)
- fix nos tests de app: `editorialmanager` pela nova restrição do `@waffle_flag`
- adiciono tests, na app `editorialmanager` para verificar que não seja possível acessar sem `@waffle_flag`.
