### PR TITLE
refactor: scielomanager/notifications.py #1027

### DIFF
--- a/scielomanager/articletrack/notifications.py
+++ b/scielomanager/articletrack/notifications.py
@@ -1,0 +1,129 @@
+# coding: utf-8
+
+import logging
+
+from scielomanager import notifications
+
+
+logger = logging.getLogger(__name__)
+
+
+class CheckinMessage(notifications.Message):
+
+    EMAIL_DATA_BY_ACTION = {
+        'checkin_reject': {
+            'subject_sufix': 'Package rejected',
+            'template_path': 'email/checkin_rejected.txt',
+        },
+        'checkin_review': {
+            'subject_sufix': 'Package reviewed',
+            'template_path': 'email/checkin_reviewed.txt',
+        },
+        'checkin_accept': {
+            'subject_sufix': 'Package accepted',
+            'template_path': 'email/checkin_accepted.txt',
+        },
+        'checkin_send_to_pending': {
+            'subject_sufix': 'Package send to pending',
+            'template_path': 'email/checkin_sent_to_pending.txt',
+        },
+        'checkin_send_to_review': {
+            'subject_sufix': 'Package sent to review',
+            'template_path': 'email/checkin_sent_to_review.txt',
+        },
+        'checkin_send_to_checkout': {
+            'subject_sufix': 'Package sent to checkout',
+            'template_path': 'email/checkin_sent_to_checkout.txt',
+        },
+        'checkout_confirmed': {
+            'subject_sufix': 'Package checkout confirmed',
+            'template_path': 'email/checkout_confirmed.txt',
+        },
+    }
+
+    def set_recipients(self, checkin):
+        """
+        Set the list of emails that will receive the message.
+        In case of checkins actions, the recipients will be the members of the team that include the user: checkin.submitted_by
+        and the submitter (checkin.submitted_by).
+        """
+        if checkin.team_members:
+            send_to = set([member.email for member in checkin.team_members])
+            # the submitter already belong to a related team
+            self.recipients = list(send_to)
+        else:
+            logger.info("[CheckinMessage.set_recipients] Can't prepare a message, checkin.team_members is empty. Checkin pk == %s" % checkin.pk)
+
+
+class TicketMessage(notifications.Message):
+
+    EMAIL_DATA_BY_ACTION = {
+        'ticket_add': {
+            'subject_sufix': 'Ticket created',
+            'template_path': 'email/ticket_created.txt',
+        },
+        'ticket_edit': {
+            'subject_sufix': 'Ticket edited',
+            'template_path': 'email/ticket_modify.txt',
+        },
+        'ticket_close': {
+            'subject_sufix': 'Ticket closed',
+            'template_path': 'email/ticket_closed.txt',
+        },
+        'comment_created': {
+            'subject_sufix': 'New comment',
+            'template_path': 'email/comment_created.txt',
+        },
+        'comment_edit': {
+            'subject_sufix': 'Comment edited',
+            'template_path': 'email/comment_modify.txt',
+        },
+    }
+
+    def set_recipients(self, ticket):
+        """
+        Set the list of emails that will receive the message.
+        In case of tickets or comments, the recipients will be:
+        the each member of a team, of each checkin related with the ticket,
+        and the submitter (checkin.submitted_by, already belong to a team) of each checkin,
+        and the author to the ticket related.
+        """
+        send_to = set([ticket.author.email, ])
+        for checkin in ticket.article.checkins.all():
+            # the submitter already belong to a related team
+            if checkin.team_members:
+                send_to.update([member.email for member in checkin.team_members])
+            else:
+                logger.info("[TicketMessage.set_recipients] Can't prepare a message, checkin.team_members is empty. Checkin pk == %s" % checkin.pk)
+        self.recipients = list(send_to)
+
+
+def checkin_send_email_by_action(checkin, action):
+
+    message = CheckinMessage(action=action, subject=checkin.package_name)
+    message.set_recipients(checkin)
+    extra_context = {'checkin': checkin, }
+    if checkin.rejected_cause:
+        extra_context['reason'] = checkin.rejected_cause
+    message.render_body(extra_context)
+    return message.send_mail()
+
+
+def ticket_send_mail_by_action(ticket, action):
+
+    message = TicketMessage(action=action)
+    message.set_recipients(ticket)
+    extra_context = {'ticket': ticket,}
+    message.render_body(extra_context)
+    return message.send_mail()
+
+
+def comment_send_mail_by_action(comment, action):
+
+    ticket = comment.ticket
+    message = TicketMessage(action=action)
+    message.set_recipients(ticket)
+    extra_context = {'ticket': ticket, 'comment': comment, }
+    message.render_body(extra_context)
+    return message.send_mail()
+

--- a/scielomanager/articletrack/tasks.py
+++ b/scielomanager/articletrack/tasks.py
@@ -5,7 +5,7 @@ import logging
 from .balaio import BalaioRPC
 from .models import Checkin
 from scielomanager.celery import app
-from scielomanager.notifications import checkin_send_email_by_action
+from articletrack.notifications import checkin_send_email_by_action
 logger = logging.getLogger(__name__)
 
 

--- a/scielomanager/articletrack/views.py
+++ b/scielomanager/articletrack/views.py
@@ -24,7 +24,7 @@ from . import models
 from .forms import CommentMessageForm, TicketForm, CheckinListFilterForm, CheckinRejectForm
 from .balaio import BalaioAPI, BalaioRPC
 from validator import utils as stylechecker_utils
-from scielomanager.notifications import checkin_send_email_by_action, ticket_send_mail_by_action, comment_send_mail_by_action
+from articletrack.notifications import checkin_send_email_by_action, ticket_send_mail_by_action, comment_send_mail_by_action
 
 AUTHZ_REDIRECT_URL = '/accounts/unauthorized/'
 MSG_FORM_SAVED = _('Saved.')

--- a/scielomanager/editorialmanager/notifications.py
+++ b/scielomanager/editorialmanager/notifications.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+
+import logging
+
+from scielomanager import notifications
+
+
+logger = logging.getLogger(__name__)
+
+
+class IssueBoardMessage(notifications.Message):
+
+    EMAIL_DATA_BY_ACTION = {
+        'issue_add_no_replicated_board': {
+            'subject_sufix': "Issue Board can't be replicated",
+            'template_path': 'email/issue_add_no_replicated_board.txt',
+        },
+        'issue_add_replicated_board': {
+            'subject_sufix': "Issue has a new replicated board",
+            'template_path': 'email/issue_add_replicated_board.txt',
+        },
+    }
+
+    def set_recipients(self, issue):
+        editor = getattr(issue.journal, 'editor', None)
+        if editor:
+            self.recipients = [editor,]
+        else:
+            logger.info("[IssueBoardMessage.set_recipients] Can't prepare a message, issue.journal.editor is None or empty. Issue pk == %s" % issue.pk)
+
+
+class BoardMembersMessage(notifications.Message):
+
+    EMAIL_DATA_BY_ACTION = {
+        'board_add_member': {
+            'subject_sufix': "Member of the journal board, was added",
+            'template_path': 'email/board_add_member.txt',
+        },
+        'board_edit_member': {
+            'subject_sufix': "Member of the journal board, was edited",
+            'template_path': 'email/board_edit_member.txt',
+        },
+        'board_delete_member': {
+            'subject_sufix': "Member of the journal board, was deleted",
+            'template_path': 'email/board_delete_member.txt',
+        }
+    }
+
+    def set_recipients(self, member):
+        from scielomanager.tools import get_users_by_group
+        from django.core.exceptions import ObjectDoesNotExist
+        try:
+            self.recipients = get_users_by_group('Librarian')
+        except ObjectDoesNotExist:
+            logger.info("[BoardMembersMessage.set_recipients] Can't prepare a message, Can't retrieve a list of Librarian Users.")
+
+
+def issue_board_replica(issue, action):
+    message = IssueBoardMessage(action=action,)
+    message.set_recipients(issue)
+    extra_context = {'issue': issue,}
+    message.render_body(extra_context)
+    return message.send_mail()
+
+
+def board_members_send_email_by_action(member, user, message, action):
+    message = BoardMembersMessage(action=action)
+    message.set_recipients(member)
+    extra_context = {
+        'user': user,
+        'member': member,
+        'issue': member.board.issue,
+        'message': message,
+    }
+    message.render_body(extra_context)
+    return message.send_mail()

--- a/scielomanager/editorialmanager/tests/tests_notifications.py
+++ b/scielomanager/editorialmanager/tests/tests_notifications.py
@@ -4,19 +4,11 @@ from django.core import mail
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-
 from django_factory_boy import auth
 
 from journalmanager.tests import modelfactories
-
-from scielomanager import notifications
-
+from editorialmanager import notifications
 from . import modelfactories as editorial_modelfactories
-
-def generate_subject(action, subject=''):
-    subject_prefix = settings.EMAIL_SUBJECT_PREFIX
-    subject_suffix = notifications.EMAIL_DATA_BY_ACTION[action]['subject_sufix']
-    return ' '.join([subject_prefix, subject, subject_suffix])
 
 
 class IssueBoardMessageTests(TestCase):
@@ -30,6 +22,15 @@ class IssueBoardMessageTests(TestCase):
         self.journal = modelfactories.JournalFactory.create(editor=self.editor)
         self.issue = modelfactories.IssueFactory(journal=self.journal)
         self.expected_recipients = [self.editor, ]
+        self.expected_subject_sufix_by_action = {
+            'issue_add_no_replicated_board': "Issue Board can't be replicated",
+            'issue_add_replicated_board': "Issue has a new replicated board",
+        }
+
+    def _make_subject(self, action, subject=''):
+        subject_prefix = settings.EMAIL_SUBJECT_PREFIX
+        subject_suffix = self.expected_subject_sufix_by_action[action]
+        return ' '.join([subject_prefix, subject, subject_suffix])
 
     def tearDown(self):
         """
@@ -41,7 +42,7 @@ class IssueBoardMessageTests(TestCase):
         email_count = 0
         for action in self.ACTIONS:
             # with
-            expected_subject = generate_subject(action=action, subject='')
+            expected_subject = self._make_subject(action)
             email_count += 1
             # when
             result = notifications.issue_board_replica(issue=self.issue, action=action)
@@ -53,6 +54,7 @@ class IssueBoardMessageTests(TestCase):
             self.assertEqual(len(self.expected_recipients), len(new_email.to))
             for recipient in self.expected_recipients:
                 self.assertIn(recipient, new_email.to)
+
 
 class BoardMembersMessageTests(TestCase):
     ACTIONS =  [
@@ -80,13 +82,23 @@ class BoardMembersMessageTests(TestCase):
         self.member = editorial_modelfactories.EditorialMemberFactory.create(board=self.board)
 
         self.expected_recipients = [self.librarian1, self.librarian2, ]
+        self.expected_subject_sufix_by_action = {
+            'board_add_member': "Member of the journal board, was added",
+            'board_edit_member': "Member of the journal board, was edited",
+            'board_delete_member': "Member of the journal board, was deleted",
+        }
+
+    def _make_subject(self, action, subject=''):
+        subject_prefix = settings.EMAIL_SUBJECT_PREFIX
+        subject_suffix = self.expected_subject_sufix_by_action[action]
+        return ' '.join([subject_prefix, subject, subject_suffix])
 
     @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
     def test_each_action(self):
         email_count = 0
         for action in self.ACTIONS:
             # with
-            expected_subject = generate_subject(action=action, subject='')
+            expected_subject = self._make_subject(action)
             message = ''
             email_count += 1
             # when

--- a/scielomanager/editorialmanager/views.py
+++ b/scielomanager/editorialmanager/views.py
@@ -16,7 +16,7 @@ from waffle.decorators import waffle_flag
 from journalmanager.models import Journal, JournalMission, Issue
 from journalmanager.forms import RestrictedJournalForm, JournalMissionForm
 
-from scielomanager import notifications
+from editorialmanager import notifications
 from scielomanager.tools import get_paginated
 from audit_log import helpers
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -45,7 +45,7 @@ from scielomanager.tools import (
 from audit_log import helpers
 from editorialmanager.models import EditorialBoard
 
-from scielomanager import notifications
+from editorialmanager import notifications
 
 MSG_FORM_SAVED = _('Saved.')
 MSG_FORM_SAVED_PARTIALLY = _('Saved partially. You can continue to fill in this form later.')


### PR DESCRIPTION
Fixes: #1027

Separação do código genérico (scielomanager/notifications.py @ Message)
do código particular (articletrack/notifications.py @ CheckinMessage, TicketMessage)
e (editorialmanager/notifications.py @ IssueBoardMessage, BoardMemberMessage)

Os tests de cada Classe *Message estão dentro da pasta de tests de cada app.
