### PR TITLE
Criação de uma API para o Editorial Manager #993

### DIFF
--- a/scielomanager/api/resources_v2.py
+++ b/scielomanager/api/resources_v2.py
@@ -12,6 +12,7 @@ from tastypie.contrib.contenttypes.fields import GenericForeignKeyField
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 
 from journalmanager import models
+from editorialmanager import models as em_models
 
 from articletrack.models import (
     Checkin,
@@ -564,3 +565,32 @@ class AheadPressReleaseResource(ModelResource):
 
         return orm_filters
 
+
+class EditorialBoardResource(ModelResource):
+    issue = fields.ToOneField(IssueResource, 'issue')
+
+    class Meta(ApiKeyAuthMeta):
+        resource_name = 'editorialboard'
+        queryset = em_models.EditorialBoard.objects.all()
+        allowed_methods = ['get', ]
+
+
+class RoleTypeResource(ModelResource):
+    weight = fields.IntegerField('weight')   #TODO: shall be removed when accepted PR: #1033
+
+    class Meta(ApiKeyAuthMeta):
+        resource_name = 'roletype'
+        queryset = em_models.RoleType.objects.all()
+        allowed_methods = ['get', ]
+        ordering = ('weight', 'name')
+
+
+class EditorialMemberResource(ModelResource):
+    role = fields.ForeignKey(RoleTypeResource, 'role')
+    board = fields.ForeignKey(EditorialBoardResource, 'board')
+
+    class Meta(ApiKeyAuthMeta):
+        resource_name = 'editorialmember'
+        queryset = em_models.EditorialMember.objects.all()
+        allowed_methods = ['get', ]
+        ordering = ('board', 'order', 'pk')

--- a/scielomanager/api/tests_resources_v2.py
+++ b/scielomanager/api/tests_resources_v2.py
@@ -6,6 +6,7 @@ from django_webtest import WebTest
 from django_factory_boy import auth
 
 from journalmanager.tests import modelfactories
+from editorialmanager.tests import modelfactories as editorial_modelfactories
 from articletrack.tests import modelfactories as articletrack_modelfactories
 from api.resources_v2 import (
     JournalResource,
@@ -1612,4 +1613,208 @@ class CommentRestAPITest(WebTest):
             u'resource_uri',
         ]
 
+        self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))
+
+
+class EditorialBoardRestAPITest(WebTest):
+
+    def setUp(self):
+        self.api_path = '/api/v2/editorialboard/'
+        self.user = auth.UserF(is_active=True)
+        self.extra_environ = _make_auth_environ(self.user.username, self.user.api_key.key)
+        # setup collection
+        self.collection = modelfactories.CollectionFactory.create()
+        self.collection.add_user(self.user, is_manager=False)
+        self.collection.make_default_to_user(self.user)
+        # journal
+        self.journal = modelfactories.JournalFactory.create()
+        self.journal.join(self.collection, self.user)
+        #set the user as editor of the journal
+        self.journal.editor = self.user
+        self.journal.save()
+        # create an issue
+        self.issue = modelfactories.IssueFactory.create()
+        self.issue.journal = self.journal
+        self.journal.save()
+        self.issue.save()
+
+    def tearDown(self):
+        pass
+
+    def test_post_data(self):
+        """ method POST not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_put_data(self):
+        """ method PUT not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_del_data(self):
+        """ method DELETE not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_access_denied_for_unauthenticated_users(self):
+        response = self.app.get(self.api_path, status=401)
+        self.assertEqual(response.status_code, 401)
+
+    def test_editorialboard_index(self):
+        # with
+        board = editorial_modelfactories.EditorialBoardFactory.create(issue=self.issue)
+        # when
+        response = self.app.get(self.api_path, extra_environ=self.extra_environ)
+        # then
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+
+    def test_api_v2_data_editorialboard(self):
+        # with
+        board = editorial_modelfactories.EditorialBoardFactory.create(issue=self.issue)
+        target_url = "%s%s/" % (self.api_path, board.pk)
+        # when
+        response = self.app.get(target_url, extra_environ=self.extra_environ)
+        # then
+        expected_keys = [
+            u'id',
+            u'issue',
+            u'resource_uri',
+        ]
+        self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))
+
+
+class RoleTypeRestAPITest(WebTest):
+
+    def setUp(self):
+        self.api_path = '/api/v2/roletype/'
+        self.user = auth.UserF(is_active=True)
+        self.extra_environ = _make_auth_environ(self.user.username, self.user.api_key.key)
+
+    def tearDown(self):
+        pass
+
+    def test_post_data(self):
+        """ method POST not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_put_data(self):
+        """ method PUT not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_del_data(self):
+        """ method DELETE not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_access_denied_for_unauthenticated_users(self):
+        response = self.app.get(self.api_path, status=401)
+        self.assertEqual(response.status_code, 401)
+
+    def test_roletype_index(self):
+        # with
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        # when
+        response = self.app.get(self.api_path, extra_environ=self.extra_environ)
+        # then
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+
+    def test_api_v2_data_roletype(self):
+        # with
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        target_url = "%s%s/" % (self.api_path, role.pk)
+        # when
+        response = self.app.get(target_url, extra_environ=self.extra_environ)
+        # then
+        expected_keys = [
+            u'id',
+            u'name',
+            u'resource_uri',
+            u'weight', # TODO: shall be removed when accepted PR: #1033
+        ]
+        self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))
+
+
+class EditorialMemberRestAPITest(WebTest):
+
+    def setUp(self):
+        self.api_path = '/api/v2/editorialmember/'
+        self.user = auth.UserF(is_active=True)
+        self.extra_environ = _make_auth_environ(self.user.username, self.user.api_key.key)
+        # setup collection
+        self.collection = modelfactories.CollectionFactory.create()
+        self.collection.add_user(self.user, is_manager=False)
+        self.collection.make_default_to_user(self.user)
+        # journal
+        self.journal = modelfactories.JournalFactory.create()
+        self.journal.join(self.collection, self.user)
+        #set the user as editor of the journal
+        self.journal.editor = self.user
+        self.journal.save()
+        # create an issue
+        self.issue = modelfactories.IssueFactory.create()
+        self.issue.journal = self.journal
+        self.journal.save()
+        self.issue.save()
+
+    def tearDown(self):
+        pass
+
+    def test_post_data(self):
+        """ method POST not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_put_data(self):
+        """ method PUT not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_del_data(self):
+        """ method DELETE not allowed """
+        response = self.app.delete(self.api_path, extra_environ=self.extra_environ, status=405)
+        self.assertEqual(response.status_code, 405)
+
+    def test_access_denied_for_unauthenticated_users(self):
+        response = self.app.get(self.api_path, status=401)
+        self.assertEqual(response.status_code, 401)
+
+    def test_editorialmember_index(self):
+        # with
+        member = editorial_modelfactories.EditorialMemberFactory.create()
+        # when
+        response = self.app.get(self.api_path, extra_environ=self.extra_environ)
+        # then
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('objects' in response.content)
+
+    def test_api_v2_data_editorialmember(self):
+        # with
+        board = editorial_modelfactories.EditorialBoardFactory.create(issue=self.issue)
+        role = editorial_modelfactories.RoleTypeFactory.create()
+        member = editorial_modelfactories.EditorialMemberFactory.create(board=board, role=role, order=1)
+        target_url = "%s%s/" % (self.api_path, member.pk)
+        # when
+        response = self.app.get(target_url, extra_environ=self.extra_environ)
+        # then
+        expected_keys = [
+            u'board',
+            u'city',
+            u'country',
+            u'email',
+            u'first_name',
+            u'id',
+            u'institution',
+            u'last_name',
+            u'link_cv',
+            u'orcid',
+            u'order',
+            u'research_id',
+            u'resource_uri',
+            u'role',
+            u'state'
+        ]
         self.assertEqual(sorted(response.json.keys()), sorted(expected_keys))

--- a/scielomanager/scielomanager/urls.py
+++ b/scielomanager/scielomanager/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls.defaults import *
 from django.contrib import admin
 from django.conf import settings
 from tastypie.api import Api
+import waffle
 
 from journalmanager import views, models
 from api import resources_v1, resources_v2
@@ -53,7 +54,11 @@ v2_api_resources = [
     resources_v2.CheckinArticleResource(),
     resources_v2.TicketResource(),
     resources_v2.CommentResource(),
-    resources_v2.PressReleaseTranslationResource()
+    resources_v2.PressReleaseTranslationResource(),
+    # editorialmanager
+    resources_v2.EditorialBoardResource(),
+    resources_v2.RoleTypeResource(),
+    resources_v2.EditorialMemberResource(),
 ]
 
 for res in v2_api_resources:


### PR DESCRIPTION
Fixes: #993

Assim que incorporados os PR: #1033 e #1031, os resources tem que se ser ajustado,
porque mudou editorialmanager.models.py (tirando o campo weight, e adicionando: RoleTypeTranslation)
