### PR TITLE
Ajustes para envio de emails usando celery

### DIFF
--- a/scielomanager/editorialmanager/notifications.py
+++ b/scielomanager/editorialmanager/notifications.py
@@ -24,7 +24,7 @@ class IssueBoardMessage(notifications.Message):
     def set_recipients(self, issue):
         editor = getattr(issue.journal, 'editor', None)
         if editor:
-            self.recipients = [editor,]
+            self.recipients = [editor.email, ]
         else:
             logger.info("[IssueBoardMessage.set_recipients] Can't prepare a message, issue.journal.editor is None or empty. Issue pk == %s" % issue.pk)
 
@@ -50,7 +50,8 @@ class BoardMembersMessage(notifications.Message):
         from scielomanager.tools import get_users_by_group
         from django.core.exceptions import ObjectDoesNotExist
         try:
-            self.recipients = get_users_by_group('Librarian')
+            librarians = get_users_by_group('Librarian')
+            self.recipients = [user.email for user in librarians if user.email]
         except ObjectDoesNotExist:
             logger.info("[BoardMembersMessage.set_recipients] Can't prepare a message, Can't retrieve a list of Librarian Users.")
 

--- a/scielomanager/editorialmanager/tests/tests_notifications.py
+++ b/scielomanager/editorialmanager/tests/tests_notifications.py
@@ -53,7 +53,7 @@ class IssueBoardMessageTests(TestCase):
             self.assertEqual(new_email.subject, expected_subject)
             self.assertEqual(len(self.expected_recipients), len(new_email.to))
             for recipient in self.expected_recipients:
-                self.assertIn(recipient, new_email.to)
+                self.assertIn(recipient.email, new_email.to)
 
 
 class BoardMembersMessageTests(TestCase):
@@ -110,4 +110,4 @@ class BoardMembersMessageTests(TestCase):
             self.assertEqual(new_email.subject, expected_subject)
             self.assertEqual(len(self.expected_recipients), len(new_email.to))
             for recipient in self.expected_recipients:
-                self.assertIn(recipient, new_email.to)
+                self.assertIn(recipient.email, new_email.to)

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -41,10 +41,10 @@ from scielomanager.tools import (
     get_paginated,
     get_referer_view,
     asbool,
+    get_users_by_group,
 )
 from audit_log import helpers
 from editorialmanager.models import EditorialBoard
-
 from editorialmanager import notifications
 
 MSG_FORM_SAVED = _('Saved.')
@@ -70,16 +70,6 @@ def get_first_letter(objects_all):
     letters_set = set(unicode(letter).strip()[0].upper() for letter in objects_all)
 
     return sorted(list(letters_set))
-
-
-def get_users_by_group(group):
-    """
-    Get all users from a group or raise a ObjectDoesNotExist
-    """
-
-    editor_group = Group.objects.get(name=group)
-
-    return editor_group.user_set.all()
 
 
 @permission_required('journalmanager.list_editor_journal', login_url=settings.AUTHZ_REDIRECT_URL)

--- a/scielomanager/scielomanager/notifications.py
+++ b/scielomanager/scielomanager/notifications.py
@@ -62,8 +62,11 @@ class Message(object):
     def set_recipients(self, *args, **kwargs):
         """
         Implement this method to update the recipients list, based in args and kwargs data.
+        *************************************************
+        * the list MUST contains a list o email strings *
+        *************************************************
         """
-        raise NotImplementedError("Please Implement this method")
+        raise NotImplementedError("Please Implement this method and remember to set a list of (emails) strings!")
 
     def send_mail(self):
         """

--- a/scielomanager/scielomanager/tools.py
+++ b/scielomanager/scielomanager/tools.py
@@ -119,6 +119,6 @@ def get_users_by_group(group):
     """
     Get all users from a Group with name:``group`` or raise a ObjectDoesNotExist
     """
-    traget_group = Group.objects.get(name=group)
-    return traget_group.user_set.all()
+    target_group = Group.objects.get(name=group)
+    return target_group.user_set.all()
 


### PR DESCRIPTION
Fixes: #1041
- recipients agora pasa uma lista de emails no lugar de objetos usuarios.
- limpeza de codigo `get_users_by_group`.
- ajustes nos tests que comparava objetos usuarios, no lugar de comparar stringsd e emails.
