### PR TITLE
Analisar o uso de envio de e-mail utilizando Celery #980

### DIFF
--- a/scielomanager/accounts/forms.py
+++ b/scielomanager/accounts/forms.py
@@ -1,5 +1,11 @@
 # coding: utf-8
 from django import forms
+from django.contrib.auth.forms import PasswordResetForm
+from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.models import get_current_site
+from django.utils.http import int_to_base36
+from django.template import loader
+from scielomanager.tasks import send_mail
 
 
 class PasswordChangeForm(forms.Form):
@@ -9,3 +15,41 @@ class PasswordChangeForm(forms.Form):
         widget=forms.PasswordInput(attrs={'class': 'span3'}))
     new_password_again = forms.CharField(
         widget=forms.PasswordInput(attrs={'class': 'span3'}))
+
+
+class PasswordResetForm(PasswordResetForm):
+    """
+    Customization of django.contrib.auth.forms:PasswordResetForm
+    to send emails via celery task
+    """
+
+    def save(self, domain_override=None,
+             subject_template_name='registration/password_reset_subject.txt',
+             email_template_name='registration/password_reset_email.html',
+             use_https=False, token_generator=default_token_generator,
+             from_email=None, request=None):
+        """
+        Generates a one-use only link for resetting password and sends to the
+        user.
+        """
+        for user in self.users_cache:
+            if not domain_override:
+                current_site = get_current_site(request)
+                site_name = current_site.name
+                domain = current_site.domain
+            else:
+                site_name = domain = domain_override
+            c = {
+                'email': user.email,
+                'domain': domain,
+                'site_name': site_name,
+                'uid': int_to_base36(user.id),
+                'user': user,
+                'token': token_generator.make_token(user),
+                'protocol': use_https and 'https' or 'http',
+            }
+            subject = loader.render_to_string(subject_template_name, c)
+            # Email subject *must not* contain newlines
+            subject = ''.join(subject.splitlines())
+            email = loader.render_to_string(email_template_name, c)
+            send_mail.delay(subject, email, [user.email])

--- a/scielomanager/accounts/urls.py
+++ b/scielomanager/accounts/urls.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.views.generic.base import TemplateView
 
 from . import views
+from . import forms
 
 
 urlpatterns = patterns('',
@@ -23,6 +24,7 @@ urlpatterns = patterns('',
             'template_name': 'registration/password_reset_form.html',
             'email_template_name':  'registration/password_reset_email.html',
             'post_reset_redirect': '/accounts/password/reset/done/',
+            'password_reset_form': forms.PasswordResetForm,
         },
         name='registration.password_reset'),
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -10,7 +10,6 @@ except ImportError:
 
 import operator
 from django.core.exceptions import ObjectDoesNotExist
-from django.contrib.auth import forms as auth_forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.decorators import user_passes_test
@@ -46,6 +45,7 @@ from scielomanager.tools import (
 from audit_log import helpers
 from editorialmanager.models import EditorialBoard
 from editorialmanager import notifications
+from accounts import forms as accounts_forms
 
 MSG_FORM_SAVED = _('Saved.')
 MSG_FORM_SAVED_PARTIALLY = _('Saved partially. You can continue to fill in this form later.')
@@ -476,7 +476,7 @@ def add_user(request, user_id=None):
             # if it is a new user, mail him
             # requesting for password change
             if not user_id:
-                password_form = auth_forms.PasswordResetForm({'email': new_user.email})
+                password_form = accounts_forms.PasswordResetForm({'email': new_user.email})
                 if password_form.is_valid():
                     opts = {
                         'use_https': request.is_secure(),


### PR DESCRIPTION
Fixes: #980 

o envio de emails era feito no método save do form: `PasswordResetForm` do modulo: `django.contrib.auth.forms`
foi feito um novo form (subclasse de `django.contrib.auth.forms:PasswordResetForm`)
e reescrito o método save, para utilizar a task do celery.

este formulario era utilizado em:
- `accounts.urls.py` para atender a url 'registration.password_reset'
- `journalmanager.views.py` para antender a 'add_user(...)'
