### PR TITLE
FIX: IntegrityError quando é criado um novo usuário - #1053

### DIFF
--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -477,8 +477,15 @@ def add_user(request, user_id=None):
                     has_set_as_default = True
                 instance.save()
 
-            # save userprofile formset forms
-            userprofileformset.save()
+            # work-around to solve bug: #1053
+            new_user_profile = new_user.get_profile()
+            profile_form = userprofileformset.forms[0] # only one form must exist (User <- OneToOne -> Profile)
+            if profile_form.has_changed():
+                for field in profile_form.changed_data:
+                    changed_field_value = profile_form.cleaned_data[field]
+                    if hasattr(new_user_profile, field):
+                        setattr(new_user_profile, field, changed_field_value)
+                        new_user_profile.save()
 
             # if it is a new user, mail him
             # requesting for password change


### PR DESCRIPTION
FIXES: #1053

``userprofileformset.save()`` como o campo: ``userprofile-0-email_notifications`` desmarcado, fazia com que o save() do formset, tentase criar um novo UserProfile para o novo usário (que já conta com um profile no momento da criação).
Então a solução tipo: "work-around" é não salvar o formset, mas recuperar os campos modificados, e fazer o ``setatt(...)`` desses campos no user profile correto.

Foi adicionado um test com a situação de salvar um novo user com o campo unchecked, para reproduzir o erro e garantir que não aconteça de novo.