### PR TITLE
#1060 - frontend para visualizar o journalmanager.article

### DIFF
--- a/scielomanager/journalmanager/migrations/0062_auto__add_field_article_abbrev_journal_title__add_index_article_aid.py
+++ b/scielomanager/journalmanager/migrations/0062_auto__add_field_article_abbrev_journal_title__add_index_article_aid.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Article.abbrev_journal_title'
+        db.add_column('journalmanager_article', 'abbrev_journal_title',
+                      self.gf('django.db.models.fields.CharField')(max_length=256, null=True, db_index=True),
+                      keep_default=False)
+
+        # Adding index on 'Article', fields ['aid']
+        db.create_index('journalmanager_article', ['aid'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'Article', fields ['aid']
+        db.delete_index('journalmanager_article', ['aid'])
+
+        # Deleting field 'Article.abbrev_journal_title'
+        db.delete_column('journalmanager_article', 'abbrev_journal_title')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.aheadpressrelease': {
+            'Meta': {'object_name': 'AheadPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Journal']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.article': {
+            'Meta': {'object_name': 'Article'},
+            'abbrev_journal_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'aid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '32', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'article_id_slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'unique': 'True', 'max_length': '2048'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_generated': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Issue']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'xml': ('scielomanager.custom_fields.XMLSPSField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.datachangeevent': {
+            'Meta': {'object_name': 'DataChangeEvent'},
+            'changed_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.issue': {
+            'Meta': {'ordering': "('created', 'id')", 'object_name': 'Issue'},
+            'cover': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_marked_up': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'label': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'blank': 'True'}),
+            'publication_end_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_start_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_year': ('django.db.models.fields.IntegerField', [], {}),
+            'section': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Section']", 'symmetrical': 'False', 'blank': 'True'}),
+            'spe_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'suppl_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'total_documents': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'regular'", 'max_length': '15'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']", 'null': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'})
+        },
+        'journalmanager.issuetitle': {
+            'Meta': {'object_name': 'IssueTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Issue']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'editor_journal'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.journalmission': {
+            'Meta': {'object_name': 'JournalMission'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'missions'", 'to': "orm['journalmanager.Journal']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']", 'null': 'True'})
+        },
+        'journalmanager.journaltimeline': {
+            'Meta': {'object_name': 'JournalTimeline'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'since': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'journalmanager.journaltitle': {
+            'Meta': {'object_name': 'JournalTitle'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'other_titles'", 'to': "orm['journalmanager.Journal']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.pendedform': {
+            'Meta': {'object_name': 'PendedForm'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_forms'", 'to': "orm['auth.User']"}),
+            'view_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.pendedvalue': {
+            'Meta': {'object_name': 'PendedValue'},
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'data'", 'to': "orm['journalmanager.PendedForm']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'journalmanager.pressrelease': {
+            'Meta': {'object_name': 'PressRelease'},
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.pressreleasearticle': {
+            'Meta': {'object_name': 'PressReleaseArticle'},
+            'article_pid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.PressRelease']"})
+        },
+        'journalmanager.pressreleasetranslation': {
+            'Meta': {'object_name': 'PressReleaseTranslation'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'to': "orm['journalmanager.PressRelease']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.regularpressrelease': {
+            'Meta': {'object_name': 'RegularPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Issue']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.section': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Section'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '21', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'legacy_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'journalmanager.sectiontitle': {
+            'Meta': {'ordering': "['title']", 'object_name': 'SectionTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'titles'", 'to': "orm['journalmanager.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.translateddata': {
+            'Meta': {'object_name': 'TranslatedData'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'translation': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['journalmanager']

--- a/scielomanager/journalmanager/modelmanagers.py
+++ b/scielomanager/journalmanager/modelmanagers.py
@@ -178,6 +178,18 @@ class IssueManager(UserObjectManager):
         return IssueQuerySet(self.model, using=self._db)
 
 
+class ArticleQuerySet(UserObjectQuerySet):
+    def all(self, get_all_collections=user_request_context.get_current_user_collections):
+        return self.filter(issue__journal__collections__in=get_all_collections())
+
+    def active(self, get_active_collection=user_request_context.get_current_user_active_collection):
+        return self.filter(issue__journal__collections=get_active_collection())
+
+
+class ArticleManager(UserObjectManager):
+    def get_query_set(self):
+        return ArticleQuerySet(self.model, using=self._db)
+
 class InstitutionQuerySet(UserObjectQuerySet):
     def all(self, get_all_collections=user_request_context.get_current_user_collections):
         return self.filter(

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -703,6 +703,12 @@ class Journal(caching.base.CachingMixin, models.Model):
         return grid
 
     @property
+    def get_articles_ahead_of_print(self):
+        orphan_articles = Article.objects.filter(issue=None, abbrev_journal_title=self.title_iso)
+        result = [article for article in orphan_articles if article.xml_is_aop]
+        return result
+
+    @property
     def succeeding_title(self):
         try:
             return self.prev_title.get()
@@ -1075,9 +1081,26 @@ class Issue(caching.base.CachingMixin, models.Model):
 
     @property
     def publication_date(self):
-        return '{0} / {1} - {2}'.format(self.publication_start_month,
-                                        self.publication_end_month,
-                                        self.publication_year)
+        start = self.get_publication_start_month_display()
+        end =  self.get_publication_end_month_display()
+        if start and end:
+            return '{0}/{1} {2}'.format(start[:3], end[:3], self.publication_year)
+        elif start:
+            return '{0} {1}'.format(start[:3], self.publication_year)
+        elif end:
+            return '{0} {1}'.format(end[:3], self.publication_year)
+        else:
+            return self.publication_year
+
+    @property
+    def verbose_identification(self):
+        if self.type == 'supplement':
+            prefixed_number = 'suppl.%s' % self.suppl_text
+        elif self.type == 'special':
+            prefixed_number = 'spe.%s' % self.spe_text
+        else: # regular
+            prefixed_number = 'n.%s' % self.number
+        return 'vol.%s %s' % (self.volume, prefixed_number)
 
     @property
     def suppl_type(self):
@@ -1101,7 +1124,15 @@ class Issue(caching.base.CachingMixin, models.Model):
                 return 'volume'
 
         else:
-            raise AttributeError('Issues of type %s do not have an attribute named: esp_type' % self.get_type_display())
+            raise AttributeError('Issues of type %s do not have an attribute named: spe_type' % self.get_type_display())
+
+    @property
+    def bibliographic_legend(self):
+        abrev_title = self.journal.title_iso
+        issue = self.verbose_identification
+        city = self.journal.publication_city
+        dates = self.publication_date
+        return '%s %s %s %s'% (abrev_title, issue, city, dates)
 
     def _suggest_order(self, force=False):
         """
@@ -1350,8 +1381,8 @@ class Article(caching.base.CachingMixin, models.Model):
     updated_at = models.DateTimeField(auto_now=True, default=datetime.datetime.now)
     is_visible = models.BooleanField(default=True)
     is_generated = models.BooleanField(default=True)
-    aid = models.CharField(max_length=32, unique=True, null=True, blank=True, editable=False)
-
+    aid = models.CharField(max_length=32, unique=True, null=True, blank=True, editable=False, db_index=True)
+    abbrev_journal_title = models.CharField(_('ISO abbreviated title'), max_length=256, null=True, blank=False, db_index=True)
     # article identification field:
     article_id_slug = models.SlugField(max_length=2048, unique=True, default='')
 
@@ -1362,6 +1393,8 @@ class Article(caching.base.CachingMixin, models.Model):
         permissions = (("list_article", "Can list Article"),)
 
     def save(self, *args, **kwargs):
+        if not self.abbrev_journal_title:
+            self.abbrev_journal_title = self.xml_abbrev_journal_title
         if not self.article_id_slug:
             self.article_id_slug = slugify(self.get_article_id_fields)
         super(Article, self).save(*args, **kwargs)

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -1341,6 +1341,7 @@ class Article(caching.base.CachingMixin, models.Model):
     """
     objects = caching.base.CachingManager()
     nocacheobjects = models.Manager()
+    userobjects = modelmanagers.ArticleManager()
 
     issue = models.ForeignKey(Issue, related_name='articles', blank=True, null=True)
     xml = XMLSPSField(blank=True, null=True)
@@ -1366,8 +1367,12 @@ class Article(caching.base.CachingMixin, models.Model):
         super(Article, self).save(*args, **kwargs)
 
     @property
+    def get_article_title(self):
+        return self.xml.xpath('//article-meta/title-group/article-title')[0].text
+
+    @property
     def get_article_id_fields(self):
-        article_title = self.xml.xpath('//article-meta/title-group/article-title')[0].text
+        article_title = self.get_article_title
         contrib_surname = self.xml.xpath('//article-meta/contrib-group/contrib[@contrib-type="author" or @contrib-type="compiler" or @contrib-type="editor" or @contrib-type="translator"]/name[1]/surname')[0].text
         year = self.xml.xpath('//article-meta/pub-date/year')[0].text
         return u'%s_%s_%s' % (article_title.strip(), contrib_surname.strip(), year.strip())

--- a/scielomanager/journalmanager/templates/journalmanager/article_detail.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_detail.html
@@ -1,58 +1,19 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
 {% load assets %}
+{% load inctag_toolbars %}
 
 {% block page_title %}{% trans "Article: " %}{{ article.get_article_title }} {% endblock %}
 
 {% block content %}
+{% journaldash_toolbar 'issue' article.issue.journal user %}
+<h4>{{ article.issue.bibliographic_legend }}</h4>
 <div class="row-fluid">
     <h4>{% trans "XML Meta" %}:</h4>
     <div class="well well-small">
         <dl class="dl-horizontal">
             <dt>{% trans "Article title" %}:</dt>
             <dd>{{ article.get_article_title|default:"--" }}</dd>
-
-            <dt>{% trans "Journal title" %}:</dt>
-            <dd>
-                {% if article.issue %}
-                    <a href="{% url journal.dash article.issue.journal.pk %}">
-                        {{ article.xml_abbrev_journal_title|default:"--" }}
-                    </a>
-                {% else %}
-                    {{ article.xml_abbrev_journal_title|default:"--" }}
-                {% endif %}
-            </dd>
-
-            <dt>{% trans "Issue volume" %}:</dt>
-            <dd>
-                {% if article.issue %}
-                    <a href="{% url issue.index article.issue.pk %}">
-                        {{ article.xml_volume|default:"--" }}
-                    </a>
-                {% else %}
-                    {{ article.xml_volume|default:"--" }}
-                {% endif %}
-            </dd>
-
-            <dt>{% trans "Issue number" %}:</dt>
-            <dd>
-                {% if article.issue %}
-                    <a href="{% url issue.index article.issue.pk %}">
-                        {{ article.xml_issue|default:"--" }}
-                    </a>
-                {% else %}
-                    {{ article.xml_issue|default:"--" }}
-                {% endif %}
-            </dd>
-
-            <dt>{% trans "Year" %}:</dt>
-            <dd>{{ article.xml_year|default:"--" }}</dd>
-
-            <dt>{% trans "Epub" %}:</dt>
-            <dd>{{ article.xml_epub|default:"--" }}</dd>
-
-            <dt>{% trans "Ppub" %}:</dt>
-            <dd>{{ article.xml_ppub|default:"--" }}</dd>
 
             <dt>{% trans "Head Subject" %}:</dt>
             <dd>{{ article.xml_head_subject|default:"--" }}</dd>
@@ -62,15 +23,6 @@
 
             <dt>{% trans "PID" %}:</dt>
             <dd>{{ article.xml_pid|default:"--" }}</dd>
-
-            <dt>{% trans "is Ahead of Print" %}:</dt>
-            <dd>
-                {% if article.xml_is_aop %}
-                    <span class="label label-success">{% trans "Yes" %}</span>
-                {% else %}
-                    <span class="label label-important">{% trans "No" %}</span>
-                {% endif %}
-            </dd>
 
             <dt>{% trans "Article Type" %}:</dt>
             <dd>{{ article.xml_article_type|default:"--" }}</dd>

--- a/scielomanager/journalmanager/templates/journalmanager/article_detail.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_detail.html
@@ -13,13 +13,37 @@
             <dd>{{ article.get_article_title|default:"--" }}</dd>
 
             <dt>{% trans "Journal title" %}:</dt>
-            <dd>{{ article.xml_abbrev_journal_title|default:"--" }}</dd>
+            <dd>
+                {% if article.issue %}
+                    <a href="{% url journal.dash article.issue.journal.pk %}">
+                        {{ article.xml_abbrev_journal_title|default:"--" }}
+                    </a>
+                {% else %}
+                    {{ article.xml_abbrev_journal_title|default:"--" }}
+                {% endif %}
+            </dd>
 
             <dt>{% trans "Issue volume" %}:</dt>
-            <dd>{{ article.xml_volume|default:"--" }}</dd>
+            <dd>
+                {% if article.issue %}
+                    <a href="{% url issue.index article.issue.pk %}">
+                        {{ article.xml_volume|default:"--" }}
+                    </a>
+                {% else %}
+                    {{ article.xml_volume|default:"--" }}
+                {% endif %}
+            </dd>
 
             <dt>{% trans "Issue number" %}:</dt>
-            <dd>{{ article.xml_issue|default:"--" }}</dd>
+            <dd>
+                {% if article.issue %}
+                    <a href="{% url issue.index article.issue.pk %}">
+                        {{ article.xml_issue|default:"--" }}
+                    </a>
+                {% else %}
+                    {{ article.xml_issue|default:"--" }}
+                {% endif %}
+            </dd>
 
             <dt>{% trans "Year" %}:</dt>
             <dd>{{ article.xml_year|default:"--" }}</dd>

--- a/scielomanager/journalmanager/templates/journalmanager/article_detail.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_detail.html
@@ -1,0 +1,106 @@
+{% extends "base_list_lv0.html" %}
+{% load i18n %}
+{% load assets %}
+
+{% block page_title %}{% trans "Article: " %}{{ article.get_article_title }} {% endblock %}
+
+{% block content %}
+<div class="row-fluid">
+    <h4>{% trans "XML Meta" %}:</h4>
+    <div class="well well-small">
+        <dl class="dl-horizontal">
+            <dt>{% trans "Article title" %}:</dt>
+            <dd>{{ article.get_article_title|default:"--" }}</dd>
+
+            <dt>{% trans "Journal title" %}:</dt>
+            <dd>{{ article.xml_abbrev_journal_title|default:"--" }}</dd>
+
+            <dt>{% trans "Issue volume" %}:</dt>
+            <dd>{{ article.xml_volume|default:"--" }}</dd>
+
+            <dt>{% trans "Issue number" %}:</dt>
+            <dd>{{ article.xml_issue|default:"--" }}</dd>
+
+            <dt>{% trans "Year" %}:</dt>
+            <dd>{{ article.xml_year|default:"--" }}</dd>
+
+            <dt>{% trans "Epub" %}:</dt>
+            <dd>{{ article.xml_epub|default:"--" }}</dd>
+
+            <dt>{% trans "Ppub" %}:</dt>
+            <dd>{{ article.xml_ppub|default:"--" }}</dd>
+
+            <dt>{% trans "Head Subject" %}:</dt>
+            <dd>{{ article.xml_head_subject|default:"--" }}</dd>
+
+            <dt>{% trans "DOI" %}:</dt>
+            <dd>{{ article.xml_doi|default:"--" }}</dd>
+
+            <dt>{% trans "PID" %}:</dt>
+            <dd>{{ article.xml_pid|default:"--" }}</dd>
+
+            <dt>{% trans "is Ahead of Print" %}:</dt>
+            <dd>
+                {% if article.xml_is_aop %}
+                    <span class="label label-success">{% trans "Yes" %}</span>
+                {% else %}
+                    <span class="label label-important">{% trans "No" %}</span>
+                {% endif %}
+            </dd>
+
+            <dt>{% trans "Article Type" %}:</dt>
+            <dd>{{ article.xml_article_type|default:"--" }}</dd>
+
+            <dt>{% trans "Article Version" %}:</dt>
+            <dd>{{ article.xml_version|default:"--" }}</dd>
+
+        </dl>
+    </div>
+    <div class="row-fluid">
+        <div class="span12">
+            <h4>{% trans "XML content" %}:</h4>
+            <div class="codemirror_wrapper">
+                {% if article.xml %}
+                    <textarea id="code" name="code">{{ article.xml }}</textarea>
+                {% else %}
+                    <textarea id="code" name="code">{% trans "This article don't have XML" %}</textarea>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% assets "codemirror_css" %}
+  <link rel="stylesheet" href="{{ ASSET_URL }}">
+{% endassets %}
+
+{% assets "codemirror_js" %}
+    <link rel="stylesheet" href="{{ ASSET_URL }}">
+    <script src="{{ ASSET_URL }}"></script>
+    <script>
+        var editor = CodeMirror.fromTextArea(
+            document.getElementById("code"),
+            {
+                lineNumbers: true,
+                lineWrapping: true,
+                mode: "application/xml",
+                styleActiveLine: true,
+                foldGutter: true,
+                gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+                matchTags: { bothTags: true },
+            });
+        {# ---- read only hack ---- listen for the beforeChange event, and cancel #}
+        editor.on('beforeChange',function(cm,change) { change.cancel(); });
+
+        {# ---- render line hack ---- #}
+        var charWidth = editor.defaultCharWidth(), basePadding = 4;
+        editor.on("renderLine", function(cm, line, elt) {
+            var off = CodeMirror.countColumn(line.text, null, cm.getOption("tabSize")) * charWidth;
+            elt.style.textIndent = "-" + off + "px";
+            elt.style.paddingLeft = (basePadding + off) + "px";
+        });
+        editor.refresh();
+    </script>
+{% endassets %}
+
+{% endblock %}

--- a/scielomanager/journalmanager/templates/journalmanager/article_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_list.html
@@ -8,24 +8,52 @@
 
 {% journaldash_toolbar 'issue' journal user %}
 
-<h4>{% trans 'Issue'%}: {{ issue }}</h4> 
-<h4>{% trans 'Publication date'%}: {{ issue.publication_date }}</h4>
+<h4>
+  {% trans 'Issue'%}: {{ issue }}
+  {% if issue.publication_start_month and issue.publication_end_month and issue.publication_year %}
+    &bull; {% trans 'Publication date'%}: {{ issue.publication_date }}
+  {% elif issue.publication_year %}
+    &bull; {% trans 'Publication year'%}: {{ issue.publication_year }}
+  {% endif %}
+</h4>
 
-<h4>{% trans 'Articles' %}</h4>
+<h5>{% trans 'Articles' %}:</h5>
 <table class="table table-striped _listings">
+  <thead>
+    <tr>
+      <th>{% trans "Title" %}:</th>
+      <th class="span3">{% trans "Created at / Updated at" %}:</th>
+      <th class="span2">{% trans "epub / ppub" %}:</th>
+      <th class="span2">{% trans "Is Visible" %}:</th>
+      <th class="span2">{% trans "Is Generated" %}:</th>
+    </tr>
+  </thead>
   <tbody>
     {% for article in articles %}
     <tr>
+      <td><a href="{% url article.detail article.pk %}">{{ article.get_article_title }}</a></td>
+      <td>{{ article.created_at }} /<br>{{ article.updated_at }}</td>
+      <td>{{ article.xml_epub|default:"--" }} /<br>{{ article.xml_ppub|default:"--" }}</td>
       <td>
-        {{ article.title }}
+        {% if article.is_visible %}
+          <span class="label label-success">{% trans "Yes" %}</span>
+        {% else %}
+          <span class="label label-important">{% trans "No" %}</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if article.is_generated %}
+          <span class="label label-success">{% trans "Yes" %}</span>
+        {% else %}
+          <span class="label label-important">{% trans "No" %}</span>
+        {% endif %}
       </td>
     </tr>
     {% empty %}
       <tr>
         <td colspan="5">
           <div class="alert alert-info">
-            <i class="icon-info-sign"></i>
-            {% trans 'There are no items.' %}
+            <i class="icon-info-sign"></i> {% trans 'There are no items.' %}
           </div>
         </td>
       </tr>

--- a/scielomanager/journalmanager/templates/journalmanager/article_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_list.html
@@ -2,56 +2,50 @@
 {% load i18n %}
 {% load inctag_toolbars %}
 
-{% block page_title %}{% trans "Journals" %}{% endblock %}
+{% block page_title %}{% trans "Articles" %}{% endblock %}
 
 {% block content %}
 
+<style>
+  .grey_bg {background-color: #f9f9f9;}
+  .article_title { margin-left: 20px;}
+</style>
+
 {% journaldash_toolbar 'issue' journal user %}
+<h4>{{ issue.bibliographic_legend }}</h4>
 
-<h4>
-  {% trans 'Issue'%}: {{ issue }}
-  {% if issue.publication_start_month and issue.publication_end_month and issue.publication_year %}
-    &bull; {% trans 'Publication date'%}: {{ issue.publication_date }}
-  {% elif issue.publication_year %}
-    &bull; {% trans 'Publication year'%}: {{ issue.publication_year }}
-  {% endif %}
-</h4>
-
-<h5>{% trans 'Articles' %}:</h5>
-<table class="table table-striped _listings">
+<table class="table _listings">
   <thead>
     <tr>
-      <th>{% trans "Title" %}:</th>
-      <th class="span3">{% trans "Created at / Updated at" %}:</th>
-      <th class="span2">{% trans "epub / ppub" %}:</th>
-      <th class="span2">{% trans "Is Visible" %}:</th>
-      <th class="span2">{% trans "Is Generated" %}:</th>
+      <th>&nbsp;</th>
+      <th class="span3">&nbsp;</th>
+      <th class="span2">&nbsp;</th>
     </tr>
   </thead>
   <tbody>
-    {% for article in articles %}
-    <tr>
-      <td><a href="{% url article.detail article.pk %}">{{ article.get_article_title }}</a></td>
-      <td>{{ article.created_at }} /<br>{{ article.updated_at }}</td>
-      <td>{{ article.xml_epub|default:"--" }} /<br>{{ article.xml_ppub|default:"--" }}</td>
-      <td>
-        {% if article.is_visible %}
-          <span class="label label-success">{% trans "Yes" %}</span>
-        {% else %}
-          <span class="label label-important">{% trans "No" %}</span>
-        {% endif %}
-      </td>
-      <td>
-        {% if article.is_generated %}
-          <span class="label label-success">{% trans "Yes" %}</span>
-        {% else %}
-          <span class="label label-important">{% trans "No" %}</span>
-        {% endif %}
-      </td>
-    </tr>
+    {% regroup articles by xml_head_subject as articles_list %}
+    {% for article_set in articles_list %}
+      <tr class="grey_bg">
+        <td>
+          <h4>{{ article_set.grouper }}</h4>
+        </td>
+        <td><strong>{% trans "Updated at" %}:</strong></td>
+        <td><strong>{% trans "Is Visible" %}:</strong></td>
+      </tr>
+      <tr>
+        {% for item in article_set.list %}
+          <td>
+            <a class="article_title" href="{% url article.detail item.pk %}">
+              {{ item.get_article_title }}
+            </a>
+          </td>
+          <td>{{ item.updated_at }}</td>
+          <td>{{ item.is_visible }}</td>
+        {% endfor %}
+      <tr>
     {% empty %}
       <tr>
-        <td colspan="5">
+        <td colspan="3">
           <div class="alert alert-info">
             <i class="icon-info-sign"></i> {% trans 'There are no items.' %}
           </div>

--- a/scielomanager/journalmanager/templates/journalmanager/issue_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/issue_list.html
@@ -1,7 +1,7 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
 {% load static %}
-{% load waffle_tags %}
+
 {% load pagination_tags %}
 {% load inctag_toolbars %}
 
@@ -42,6 +42,47 @@
   {% endif %}
 </div>
 
+
+<div class="accordion" id="accordion-aop">
+  <div class="accordion-group">
+    <div class="accordion-heading">
+      <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion-aop" href="#collapse_aop">
+        {% trans "Ahead of print" %}: <span class="label">{{ aop_articles|length }}</span> {% trans "Articles" %}
+      </a>
+    </div>
+    <div id="collapse_aop" class="accordion-body collapse {% if aop_articles|length > 0 %} in {% endif %}">
+      <div class="accordion-inner">
+        <table class="table table-hover table-condensed">
+          <thead>
+            <tr>
+              <th>{% trans "Title" %}:</th>
+              <th>{% trans "DOI" %}:</th>
+              <th>{% trans "Type" %}:</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for a in aop_articles %}
+              <tr>
+                  <td>
+                    <a href="{% url article.detail a.pk %}">
+                      {{ a.get_article_title|default:"--" }}
+                    </a>
+                  </td>
+                  <td>{{ a.xml_doi|default:"--" }}</td>
+                  <td>{{ a.xml_article_type|default:"--" }}</td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="4">{% trans 'There are no items.' %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="accordion" id="accordion-issues">
   <div class="accordion-group">
     {% for year, vols in issue_grid.items %}
@@ -60,9 +101,7 @@
               <thead>
                 <tr>
                   <th>{% trans "Number" %}:</th>
-                  {% flag 'articletrack' %}
-                    <th>{% trans "Articles" %}:</th>
-                  {% endflag %}
+                  <th>{% trans "Articles" %}:</th>
                   <th>{% trans "Total documents" %}:</th>
                   <th>{% trans "Publication months" %}:</th>
                   <th>{% trans "Updated" %}:</th>
@@ -73,7 +112,7 @@
                 {% for num in nums %}
                   <tr>
                       <td>
-                        <a href="{% url issue.edit journal.pk num.id %}">
+                        <a href="{% url article.index num.id %}">
                           {% if num.type == 'regular' and not num.number %}
                             {% trans 'volume issue' %}
                           {% else %}
@@ -81,12 +120,9 @@
                           {% endif %}
                         </a>
                       </td>
-                      {% flag 'articletrack' %}
-                        <td>
-                          <span class="label">{{ num.articles.all|length }} {% trans "articles" %}</span>
-                          <a  class='btn btn-mini' href="{% url article.index num.id %}">{% trans "view articles" %}</a>
-                        </td>
-                      {% endflag %}
+                      <td>
+                        <span class="label">{{ num.articles.all|length }} {% trans "articles" %}</span>
+                      </td>
                       <td>
                         <span class="badge {% if num.total_documents == num.articles.all|length %} badge-success {% endif %}">
                           {{ num.total_documents }}

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -156,7 +156,7 @@ class IssueTests(TestCase):
 
     def test_publication_date(self):
         issue = IssueFactory.create()
-        expected = '9 / 11 - 2012'
+        expected = 'September/November 2012'
 
         self.assertEqual(issue.publication_date, expected)
 

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -156,7 +156,7 @@ class IssueTests(TestCase):
 
     def test_publication_date(self):
         issue = IssueFactory.create()
-        expected = 'September/November 2012'
+        expected = 'Sep/Nov 2012'
 
         self.assertEqual(issue.publication_date, expected)
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -217,6 +217,7 @@ def issue_index(request, journal_id):
             'issue_grid': journal.issues_as_grid(
                 request.GET.get('is_available')
             ),
+            'aop_articles': journal.get_articles_ahead_of_print
         },
         context_instance=RequestContext(request)
     )
@@ -287,6 +288,7 @@ def article_detail(request, article_pk):
         'journalmanager/article_detail.html',
         {
             'article': article,
+            'journal': article.issue.journal, # necessario para o journal title + edit do journal no topo
         },
         context_instance=RequestContext(request)
     )

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -278,6 +278,19 @@ def article_index(request, issue_id):
         context_instance=RequestContext(request)
     )
 
+@permission_required('journalmanager.list_article', login_url=settings.AUTHZ_REDIRECT_URL)
+def article_detail(request, article_pk):
+
+    article = get_object_or_404(models.Article.userobjects.active(), pk=article_pk)
+
+    return render_to_response(
+        'journalmanager/article_detail.html',
+        {
+            'article': article,
+        },
+        context_instance=RequestContext(request)
+    )
+
 
 @permission_required('journalmanager.list_pressrelease', login_url=settings.AUTHZ_REDIRECT_URL)
 def pressrelease_index(request, journal_id):

--- a/scielomanager/scielomanager/static/css/style.css
+++ b/scielomanager/scielomanager/static/css/style.css
@@ -377,24 +377,24 @@ table._listings h4 {
   padding: 5px;
 }
 
-#accordion-issues .accordion-heading {
+.accordion-heading {
   background-color: #F5F5F5;
   border: 1px solid #DDDDDD;
   margin-top: 1px;
 }
 
-#accordion-issues .accordion-heading a {
+.accordion-heading a {
   text-decoration: none;
   color:#333;
   font-weight: bold;
 }
 
-#accordion-issues .accordion-body.collapse.in {
+.accordion-body.collapse.in {
   border-bottom: 1px solid #DDDDDD;
   margin-bottom: 10px;
 }
 
-#accordion-issues .accordion-group {
+.accordion-group {
   border-left: 1px solid #E5E5E5;
   border-right: 1px solid #E5E5E5;
   border-radius: 4px;

--- a/scielomanager/scielomanager/urls.py
+++ b/scielomanager/scielomanager/urls.py
@@ -74,6 +74,7 @@ urlpatterns = patterns('',
 
     # Article APP
     url(r'^issue/(?P<issue_id>\d+)/articles/$', views.article_index, name='article.index'),
+    url(r'^articles/(?P<article_pk>\d+)/$', views.article_detail, name='article.detail'),
 
     # Journal Manager APP
     url(r'^journal/', include('journalmanager.urls')),


### PR DESCRIPTION
- models.Article agora tem custom manager: ``userobjects = modelmanagers.ArticleManager()``
- template: ``article_list.html`` adaptado para o novos campos do modelo Article.
- novo template: ``article_detail.html`` para mostrar os dados do Artigo e o XML com syntax highlight
- nova view: ``article_detail``