### PR TITLE
#1066 - Internal Server Error: /journal/ajx/ajx1/

### DIFF
--- a/scielomanager/export/templates/export/markup_files.html
+++ b/scielomanager/export/templates/export/markup_files.html
@@ -84,6 +84,10 @@
 <script type="text/javascript">
 
   function qry_data(journal, is_all) {
+    if (!journal || journal === "") {
+      alert("{% trans 'Please select a Journal' %}");
+      return false;
+    }
     $('#loading').show();
     $.ajax({
       url: "{% url ajx.list_issues_for_markup_files %}?j=" + journal + "&all=" + is_all,
@@ -98,6 +102,10 @@
         $("#{{form.issue.auto_id}}").append('<option value="ahead:2013">' + '2013 - Ahead' + '</option>');
         $('#loading').hide();
       }
+    }).fail(function() {
+      alert( "Unexpected error when retrieving issues for markup files." );
+    }).always(function() {
+      $('#loading').hide();
     });
   }
 

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -1261,6 +1261,11 @@ def ajx_list_issues_for_markup_files(request):
         return HttpResponse(status=400)
 
     journal_id = request.GET.get('j', None)
+
+    if journal_id is None:
+        # journal id is required is None -> Raise Bad Request
+        return HttpResponse(status=400)
+
     journal = get_object_or_404(models.Journal, pk=journal_id)
 
     all_issues = asbool(request.GET.get('all', True))


### PR DESCRIPTION
FIXES: #1066 

- adiciono validação js para confirmar que o ajax, recebe o dado do journal.
- caso o ajax retorne algum erro, notifica o usuário. antes só via o loading spinner ad infinitum
- na view do ajax: se não vem algum valor no ``journal_id``, retorna um HTTP 400 - Bad Request.
