### PR TITLE
1063 manager timezone aware

### DIFF
--- a/scielomanager/accounts/templates/accounts/my_account.html
+++ b/scielomanager/accounts/templates/accounts/my_account.html
@@ -1,28 +1,148 @@
 {% extends "base_lv1.html" %}
 {% load i18n %}
+{% load user_avatar %}
+{% block content %}
+<style>
+    #accountTabContent { min-height: 470px; }
+    .avatar-rounded{ border-radius: 6px 6px 0 0; }
+</style>
 
-{% block breadcrumb %}
-<ul class="breadcrumb">
-    <li><a href="{% url index %}">{% trans 'Home' %}</a> <span class="divider">/</span></li>
-    <li class="active">{% trans 'My Account' %}</li>
-</ul>
+<div class="row-fluid">
+    <div class="span9 offset2">
+        <div class="row-fluid">
+            <div class="span12">
+                <h4>{% trans "User information" %}:</h4>
+                <div class="span8 well">
+                    <dl>
+                        <dt>{% trans "First name" %}:</dt>
+                        <dd>{{ user.first_name }}</dd>
+                        <dt>{% trans "Last name" %}:</dt>
+                        <dd>{{ user.last_name }}</dd>
+                        <dt>{% trans "Username" %}:</dt>
+                        <dd>{{ user.username }}</dd>
+                        <dt>{% trans "Email" %}:</dt>
+                        <dd>{{ user.email }}</dd>
+                    </dl>
+                    <br>
+                </div>
+                <div class="span3">
+                    <img class="avatar-rounded" src="{% user_avatar_url request.user '192' %}" alt="">
+                    <div class="alert alert-info">
+                        <small>
+                            <em>
+                                Change your avatar at:
+                                <a href="https://secure.gravatar.com">
+                                    https://secure.gravatar.com
+                                </a>
+                            </em>
+                        </small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <ul class="nav nav-tabs" id="accountTab">
+                <li class="active">
+                    <a data-toggle="tab" href="#profile">
+                        <i class="icon icon-user"></i> {% trans "Profile" %}:
+                    </a>
+                </li>
+                <li>
+                    <a data-toggle="tab" href="#collections">
+                        <i class="icon icon-book"></i> {% trans "My Collections" %}:
+                    </a>
+                </li>
+                <li>
+                    <a data-toggle="tab" href="#api_keys">
+                        <i class="icon icon-lock"></i> {% trans "API token" %}:
+                    </a>
+                </li>
+            </ul>
+            <div class="tab-content" id="accountTabContent">
+                <div id="profile" class="tab-pane in active">
+                    <div class="span6">
+                        <h4>{% trans "Change Password" %}:</h4>
+                        <div class="well">
+                            <form id="change_password_form" action="{% url journalmanager.password_change %}" method="POST">
+                                {% with password_form as form %}
+                                    {% include "articletrack/includes/form_snippet.html" %}
+                                {% endwith %}
+                            </form>
+                            <br>
+                        </div>
+                    </div>
+                    <div class="span6">
+                        <h4>{% trans "Notifications & Other preferences" %}:</h4>
+                        <div class="well">
+                            <form id="profile_form" action="." method="POST">
+                                {% with profile_form as form %}
+                                    {% include "articletrack/includes/form_snippet.html" %}
+                                {% endwith %}
+                            </form>
+                            <br>
+                        </div>
+                    </div>
+                </div>
+                <div id="collections" class="tab-pane">
+                    <div class="span12">
+                        <h4>{% trans "My collections" %}:</h4>
+                        <div class="well">
+                            <table class="table table-condensed table-hover">
+                                <thead>
+                                    <tr>
+                                        <th class="span1">#</th>
+                                        <th>{% trans "Collection" %}:</th>
+                                        <th class="span2">{% trans "Am I manager?" %}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for collection in my_collecttions %}
+                                        <tr>
+                                            <td>{{ forloop.counter }}</td>
+                                            <td>{{ collection.name }}</td>
+                                            <td>
+                                                {% if collection.is_manager %}
+                                                    <i class="icon icon-ok"></i>
+                                                {% else %}
+                                                    <i class="icon icon-remove"></i>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="2">{% trans "No collections related yet!" %}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <div id="api_keys" class="tab-pane">
+                    <div class="span12">
+                        <h4>{% trans "API Token" %}:</h4>
+                        <div class="well">
+                            <p>{% trans "This is your token" %}: <code>{{user.api_key.key}}</code></p>
+                            <p>
+                                <a href="http://docs.scielo.org/projects/scielo-manager/en/latest/dev/api.html" target="_blank">
+                                    {% trans 'Read more about the API usage' %}
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
-{% block content %}
-    <div class="span8">
-        <ul>
-            <li><a href="{% url journalmanager.password_change %}">Change my password</a></li>
-            <li>Update my personal information</li>
-        </ul>
-    </div>
-    <div class="span4 alert alert-info">
-        <h4>API Token</h4>
-        <p>{{user.api_key.key}}</p>
-        <p>
-            <a href="http://docs.scielo.org/projects/scielo-manager/en/latest/dev/api.html"
-               target="_blank">
-                {% trans 'Read more about the API usage' %}
-            </a>
-        </p>
-    </div>
+{% block extrafooter %}
+{{ block.super }}
+ <script>
+    $(document).ready(function() {
+      $('input', '#change_password_form').removeClass('span3').addClass('span12');
+      $('select', '#profile_form').addClass('span12').chosen();
+    });
+  </script>
 {% endblock %}

--- a/scielomanager/articletrack/templates/articletrack/includes/article_and_checkin_information.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/article_and_checkin_information.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load tz %}
 <div class="row-fluid show-grid">
   <div class="span12">
 
@@ -51,7 +52,7 @@
           <dt>{% trans "Package name" %}:</dt>
           <dd>{{ checkin.package_name }}</dd>
           <dt>{% trans "Updated at" %}:</dt>
-          <dd>{{ checkin.created_at|date:"d/m/Y - H:i" }}</dd>
+          <dd>{{ checkin.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</dd>
           <dt>{% trans "Submitted by" %}:</dt>
           {% if checkin.submitted_by %}
             <dd>
@@ -75,7 +76,7 @@
                 {% endwith %}
               </dd>
               <dt>{% trans "Reviewed at" %}:</dt>
-              <dd>{{ checkin.reviewed_at|date:"d/m/Y - H:i" }}</dd>
+              <dd>{{ checkin.reviewed_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</dd>
             {% endif %}
 
             {%if checkin.scielo_reviewed_by %}
@@ -88,7 +89,7 @@
                 {% endwith %}
               </dd>
               <dt>{% trans "Reviewed at" %}:</dt>
-              <dd>{{ checkin.scielo_reviewed_at|date:"d/m/Y - H:i" }}</dd>
+              <dd>{{ checkin.scielo_reviewed_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</dd>
             {% endif %}
 
           {% endif %}
@@ -103,7 +104,7 @@
                 {% endwith %}
               </dd>
               <dt>{% trans "Accepted at" %}:</dt>
-              <dd>{{ checkin.accepted_at|date:"d/m/Y - H:i" }}</dd>
+              <dd>{{ checkin.accepted_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</dd>
 
           {% elif checkin.is_rejected %}
               <dt style="text-align: left;"><em>{% trans "Rejection info" %}:</em></dt>
@@ -115,7 +116,7 @@
                 {% endwith %}
               </dd>
               <dt>{% trans "Rejected at" %}:</dt>
-              <dd>{{ checkin.rejected_at|date:"d/m/Y - H:i" }}</dd>
+              <dd>{{ checkin.rejected_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</dd>
               <dt>{% trans "Rejected reason" %}:</dt>
               <dd>{{ checkin.rejected_cause }}</dd>
 
@@ -125,7 +126,7 @@
               <dt>{% trans "Will Expire at" %}:</dt>
               <dd>
                 <span class="label label-important">
-                  {{ checkin.expiration_at|date:"d/m/Y - H:i" }}
+                  {{ checkin.expiration_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
                 </span>
               </dd>
           {% endif %}

--- a/scielomanager/articletrack/templates/articletrack/includes/checkin_list_and_filterform.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/checkin_list_and_filterform.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load tz %}
 {% load pagination_tags %}
 {% load trans_status %}
 
@@ -43,7 +44,7 @@
         <td>{{ checkin.article.article_title }}</td>
         <td>{{ checkin.article.journal_title }}</td>
         <td>{{ checkin.article.issue_label }}</td>
-        <td>{{ checkin.created_at|date:"d/m/Y - H:i" }}</td>
+        <td>{{ checkin.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</td>
         <td>
           {% if checkin.get_error_level == 'in progress' %}
             <span class="label label-info">
@@ -55,13 +56,13 @@
         </td>
         {% if status == "review" %}
           <td>{{ checkin.reviewed_by.get_full_name|default:"--" }}</td>
-          <td>{{ checkin.reviewed_at|date:"d/m/Y - H:i"|default:"--" }}</td>
+          <td>{{ checkin.reviewed_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i"|default:"--" }}</td>
         {% elif status == "accepted" %}
           <td>{{ checkin.accepted_by.get_full_name|default:"--" }}</td>
-          <td>{{ checkin.accepted_at|date:"d/m/Y - H:i"|default:"--" }}</td>
+          <td>{{ checkin.accepted_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i"|default:"--" }}</td>
         {% elif status == "rejected" %}
           <td>{{ checkin.rejected_by.get_full_name|default:"--" }}</td>
-          <td>{{ checkin.rejected_at|date:"d/m/Y - H:i"|default:"--" }}</td>
+          <td>{{ checkin.rejected_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i"|default:"--" }}</td>
         {% endif %}
         <td>
           <div class="btn-group">

--- a/scielomanager/articletrack/templates/articletrack/includes/checkin_status_notice_block.html
+++ b/scielomanager/articletrack/templates/articletrack/includes/checkin_status_notice_block.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load tz %}
 <div class="row-fluid show-grid">
   <div class="span12">
 
@@ -11,7 +12,7 @@
           {% with checkin.rejected_by as user %}
             {% include "articletrack/includes/gravatar_tooltip.html" %}
           {% endwith %}
-          {% trans "at" %} {{ checkin.rejected_at|date:"d/m/Y - H:i" }}
+          {% trans "at" %} {{ checkin.rejected_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
         </p>
       </div>
 
@@ -24,7 +25,7 @@
           {% with checkin.accepted_by as user %}
             {% include "articletrack/includes/gravatar_tooltip.html" %}
           {% endwith %}
-          {% trans "at" %} {{ checkin.accepted_at|date:"d/m/Y - H:i" }}
+          {% trans "at" %} {{ checkin.accepted_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
         </p>
       </div>
 
@@ -53,7 +54,7 @@
         <h4><i class="icon-ok-circle"></i> {% trans "THIS CHECKIN WILL EXPIRE TODAY" %}:</h4>
         <p>
           {% trans "This checkin will expire at: " %}
-          {% trans "at" %} {{ checkin.expiration_at|date:"d/m/Y - H:i" }}
+          {% trans "at" %} {{ checkin.expiration_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
         </p>
         <p>
           {% trans "After that date, the checkin will be unreachable." %}

--- a/scielomanager/articletrack/templates/articletrack/notice_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/notice_detail.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load tz %}
 {% load static %}
 {% load trans_status %}
 {% load user_avatar %}
@@ -192,7 +193,7 @@
                     {{ notice.message }}
                   </td>
                   <td>
-                    {{ notice.created_at|date:"d/m/Y - H:i" }}
+                    {{ notice.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
                   </td>
                 </tr>
               {% empty %}
@@ -356,7 +357,7 @@
       <tr {% if check.pk == checkin.pk %}class="current_attempt"{% endif %}>
         <td>{{ forloop.revcounter }}</td>
         <td>
-          {{ check.created_at|date:"d/m/Y - H:i"  }}
+          {{ check.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i"  }}
           {% if check.pk == checkin.pk %}
             <span class="label">{% trans "current" %}</span>
           {% endif %}

--- a/scielomanager/articletrack/templates/articletrack/ticket_add.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_add.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load tz %}
 
 {% block page_title %}{% trans "Add a Ticket" %}{% endblock %}
 
@@ -19,7 +20,7 @@
       <tr>
         <td>{{ checkin.package_name }}</td>
         <td>{{ checkin.attempt_ref }}</td>
-        <td>{{ checkin.created_at|date:"d/m/Y - H:i" }}</td>
+        <td>{{ checkin.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}</td>
       </tr>
     </table>
   </div>

--- a/scielomanager/articletrack/templates/articletrack/ticket_detail.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_detail.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load tz %}
 {% load urlize_ticket %}
 {% load user_avatar %}
 
@@ -29,9 +30,9 @@
   <div class="page-header">
     <h1>
       {% if ticket.is_open %}
-        <span class="label label-success">{% trans "Open" %}</span> 
+        <span class="label label-success">{% trans "Open" %}</span>
       {% else %}
-        <span class="label label-important">{% trans "Closed" %}</span> 
+        <span class="label label-important">{% trans "Closed" %}</span>
       {% endif %}
       {{ ticket.title|capfirst|urlize_ticket_link }} <small>#{{ ticket.pk }}</small>
     </h1>
@@ -49,7 +50,7 @@
     <div class="span12">
       <p class='muted'>
         <img  class="img-rounded" src="{% user_avatar_url ticket.author 'medium' %}" alt="Gravatar">
-        {{ ticket.author.get_full_name }} 
+        {{ ticket.author.get_full_name }}
         {% trans "created this ticket" %}
         <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ ticket.started_at }}'>{{ ticket.started_at|timesince }} {% trans "ago" %}</a>
         <span class='pull-right'>
@@ -62,9 +63,9 @@
     </div>
 
     {% if ticket.is_open %}
-    
+
       <div id='action_buttons_row'>
-                
+
         {% if perms.articletrack.change_ticket %}
 
           <div class="btn-group pull-right">
@@ -100,7 +101,7 @@
   {% endif %}
   <hr>
   <!-- COMMENTS -->
-  
+
   <a name="comments"></a><br><br>
   <div class="row-fluid show-grid">
     <div class="span9">
@@ -128,11 +129,16 @@
       <div class="span11">
         <div class='comment_left_arrow_box'>
           <small>
-            {% trans "Commented" %}: 
-            <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.created_at }}'>{{ comment.created_at|timesince }} {% trans "ago" %}</a>
-            {% if comment.created_at|date:"d/m/Y - H:i" != comment.updated_at|date:"d/m/Y - H:i" %}
+            {% trans "Commented" %}:
+            <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.created_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}'>
+              {{ comment.created_at|timesince }} {% trans "ago" %}
+            </a>
+            {% if comment.created_at|date:"d/m/Y - H:i" != comment.updated_at|date:"d/m/Y - H:i" %} {# no timezone conversion required here #}
               <em>
-                ({% trans "Updated" %}: <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.updated_at }}'>{{ comment.updated_at|timesince }} {% trans "ago" %}</a>)
+                ({% trans "Updated" %}:
+                <a class='muted time_ago_tooltip' href='#' data-toggle="tooltip" title='{{ comment.updated_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}'>
+                  {{ comment.updated_at|timesince }} {% trans "ago" %}
+                </a>)
               </em>
             {% endif %}
             {% if request.user == comment.author and comment.ticket.is_open %}
@@ -161,7 +167,7 @@
     $(document).ready(function(){
       $('#form_error_msg').text('').hide();
       $('#add_comment').click(function(event){
-        event.preventDefault(); 
+        event.preventDefault();
         $('#action_buttons_row').hide();
         $('#add_comment_section_row').show();
         $('#id_message').focus();

--- a/scielomanager/articletrack/templates/articletrack/ticket_list.html
+++ b/scielomanager/articletrack/templates/articletrack/ticket_list.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load tz %}
 {% load pagination_tags %}
 
 {% block page_title %}{% trans "List of Tickets" %}{% endblock %}
@@ -40,7 +41,7 @@
         {{ ticket.title }}
       </td>
       <td>
-        {{ ticket.started_at|date:"d/m/Y - H:i" }}
+        {{ ticket.started_at|timezone:user.get_profile.tz|date:"d/m/Y - H:i" }}
       </td>
       <td>
       	{% if ticket.is_open %}

--- a/scielomanager/journalmanager/forms.py
+++ b/scielomanager/journalmanager/forms.py
@@ -758,7 +758,10 @@ def get_all_ahead_pressrelease_forms(post_dict, journal, pressrelease):
 class UserProfileForm(ModelForm):
     class Meta:
         model = models.UserProfile
-        fields = ('email_notifications',)
+        fields = ('email_notifications', 'tz', )
+        widgets = {
+            'tz': forms.Select(attrs={'class': 'chosen-select',}),
+        }
 
 class UserCollectionsForm(ModelForm):
     def __init__(self, *args, **kwargs):

--- a/scielomanager/journalmanager/migrations/0062_auto__add_field_userprofile_tz.py
+++ b/scielomanager/journalmanager/migrations/0062_auto__add_field_userprofile_tz.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'UserProfile.tz'
+        db.add_column('journalmanager_userprofile', 'tz',
+                      self.gf('django.db.models.fields.CharField')(default='America/Sao_Paulo', max_length=150),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'UserProfile.tz'
+        db.delete_column('journalmanager_userprofile', 'tz')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.aheadpressrelease': {
+            'Meta': {'object_name': 'AheadPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Journal']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.article': {
+            'Meta': {'object_name': 'Article'},
+            'front': ('jsonfield.fields.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'images_url': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.Issue']"}),
+            'pdf_url': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'xml_url': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.datachangeevent': {
+            'Meta': {'object_name': 'DataChangeEvent'},
+            'changed_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.issue': {
+            'Meta': {'ordering': "('created', 'id')", 'object_name': 'Issue'},
+            'cover': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_marked_up': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'label': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'blank': 'True'}),
+            'publication_end_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_start_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_year': ('django.db.models.fields.IntegerField', [], {}),
+            'section': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Section']", 'symmetrical': 'False', 'blank': 'True'}),
+            'spe_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'suppl_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'total_documents': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'regular'", 'max_length': '15'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']", 'null': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'})
+        },
+        'journalmanager.issuetitle': {
+            'Meta': {'object_name': 'IssueTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Issue']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'editor_journal'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.journalmission': {
+            'Meta': {'object_name': 'JournalMission'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'missions'", 'to': "orm['journalmanager.Journal']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']", 'null': 'True'})
+        },
+        'journalmanager.journaltimeline': {
+            'Meta': {'object_name': 'JournalTimeline'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'since': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'journalmanager.journaltitle': {
+            'Meta': {'object_name': 'JournalTitle'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'other_titles'", 'to': "orm['journalmanager.Journal']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.pendedform': {
+            'Meta': {'object_name': 'PendedForm'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_forms'", 'to': "orm['auth.User']"}),
+            'view_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.pendedvalue': {
+            'Meta': {'object_name': 'PendedValue'},
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'data'", 'to': "orm['journalmanager.PendedForm']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'journalmanager.pressrelease': {
+            'Meta': {'object_name': 'PressRelease'},
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.pressreleasearticle': {
+            'Meta': {'object_name': 'PressReleaseArticle'},
+            'article_pid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.PressRelease']"})
+        },
+        'journalmanager.pressreleasetranslation': {
+            'Meta': {'object_name': 'PressReleaseTranslation'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'to': "orm['journalmanager.PressRelease']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.regularpressrelease': {
+            'Meta': {'object_name': 'RegularPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Issue']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.section': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Section'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '21', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'legacy_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'journalmanager.sectiontitle': {
+            'Meta': {'ordering': "['title']", 'object_name': 'SectionTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'titles'", 'to': "orm['journalmanager.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.translateddata': {
+            'Meta': {'object_name': 'TranslatedData'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'translation': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'email_notifications': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tz': ('django.db.models.fields.CharField', [], {'default': "'America/Sao_Paulo'", 'max_length': '150'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['journalmanager']

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import choices
 import caching.base
+from pytz import all_timezones
 from scielomanager import tools
 
 try:
@@ -299,12 +300,16 @@ class Language(caching.base.CachingMixin, models.Model):
         ordering = ['name']
 
 
+PROFILE_TIMEZONES_CHOICES = zip(all_timezones, all_timezones)
+
+
 class UserProfile(caching.base.CachingMixin, models.Model):
     objects = caching.base.CachingManager()
     nocacheobjects = models.Manager()
 
     user = models.OneToOneField(User)
-    email_notifications = models.BooleanField("Manager Email Notifications?", default=True)
+    email_notifications = models.BooleanField("Want to receive email notifications?", default=True)
+    tz = models.CharField("Time Zone",  max_length=150, choices=PROFILE_TIMEZONES_CHOICES, default=settings.TIME_ZONE)
 
     @property
     def is_editor(self):

--- a/scielomanager/journalmanager/templates/journalmanager/add_user.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_user.html
@@ -222,6 +222,7 @@
 {{ block.super }}
  <script>
     $(document).ready(function() {
+      $('.chosen-select').chosen()
       $( "#id_user-collection" ).combobox({ autoFocus: true });
       $(".help-text").popover('hide');
       $( "#toggle" ).click(function() {

--- a/scielomanager/journalmanager/templates/journalmanager/article_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_list.html
@@ -8,8 +8,8 @@
 
 {% journaldash_toolbar 'issue' journal user %}
 
-<h4>{% trans 'Issue'%}: {{ issue }}</h4> 
-<h4>{% trans 'Publication date'%}: {{ issue.publication_date }}</h4>
+<h4>{% trans 'Issue'%}: {{ issue }}</h4>
+<h4>{% trans 'Publication date'%}: {{ issue.publication_date }}</h4>{# no timezone conversion requiered #}
 
 <h4>{% trans 'Articles' %}</h4>
 <table class="table table-striped _listings">

--- a/scielomanager/journalmanager/templates/journalmanager/home_journal.html
+++ b/scielomanager/journalmanager/templates/journalmanager/home_journal.html
@@ -1,5 +1,6 @@
 {% extends "base_lv1.html" %}
 {% load i18n %}
+{% load tz %}
 {% load static %}
 {% load get_title_for_pended %}
 {% load inctag_toolbars %}
@@ -23,7 +24,7 @@
                  class="tip-bottom"
                  rel="tooltip"
                  data-original-title="{% get_title_for_pended pending_journal %}">
-                {{pending_journal.created_at|date:"D, d \de F \de Y - H:i"}}
+                {{pending_journal.created_at|timezone:user.get_profile.tz|date:"D, d \de F \de Y - H:i:s"}}
               </a>
             </td>
             <td>
@@ -72,7 +73,9 @@
                    rel="tooltip"
                    data-original-title="{{ activity.title }}">{{ activity.short_title }}</a>
             </td>
-            <td>{{ activity.updated|date:"r" }}</td>
+            <td>
+              {{ activity.updated|timezone:user.get_profile.tz|date:"d/m/Y - H:i:s"}}
+            </td>
           </tr>
           {% empty %}
           <tr>

--- a/scielomanager/journalmanager/templates/journalmanager/issue_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/issue_list.html
@@ -1,5 +1,6 @@
 {% extends "base_list_lv0.html" %}
 {% load i18n %}
+{% load tz %}
 {% load static %}
 {% load waffle_tags %}
 {% load pagination_tags %}
@@ -93,7 +94,7 @@
                         </span>
                       </td>
                       <td>{{ num.get_publication_start_month_display }}/{{ num.get_publication_end_month_display }}</td>
-                      <td>{{ num.updated|date:"d/m/Y - H:i"  }}</td>
+                      <td>{{ num.updated|timezone:user.get_profile.tz|date:"d/m/Y - H:i"  }}</td>
                       <td>
                         <a href="{% url issue.edit journal.pk num.id %}" class="btn btn-mini">
                           {% trans "Edit" %}

--- a/scielomanager/journalmanager/templatetags/user_avatar.py
+++ b/scielomanager/journalmanager/templatetags/user_avatar.py
@@ -38,18 +38,18 @@ def user_avatar_url(user, size):
         size = int(size)
     else:
         return '' # unknow size, no photo
+
+    if not user or not user.is_authenticated() or not user.email:
+        return ''
+
     try:
-        user_gravatar_email = user.email
-    except AttributeError: # possible user is None
+        user_profile = user.get_profile()
+    except UserProfile.DoesNotExist:
         return ''
     else:
-        if user_gravatar_email:
-            user_gravatar_id = user.get_profile().gravatar_id
-            params = urllib.urlencode({'s': size, 'd': 'mm'})
-            gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
-            avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_gravatar_id, params)
-            return avartar_url
-        else:
-            return ''
+        params = urllib.urlencode({'s': size, 'd': 'mm'})
+        gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
+        avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_profile.gravatar_id, params)
+        return avartar_url
 
 register.simple_tag(user_avatar_url)

--- a/scielomanager/journalmanager/templatetags/user_avatar.py
+++ b/scielomanager/journalmanager/templatetags/user_avatar.py
@@ -39,11 +39,12 @@ def user_avatar_url(user, size):
     else:
         return '' # unknow size, no photo
     try:
-        user_gravatar_id = user.email
+        user_gravatar_email = user.email
     except AttributeError: # possible user is None
         return ''
     else:
-        if user_gravatar_id:
+        if user_gravatar_email:
+            user_gravatar_id = user.get_profile().gravatar_id
             params = urllib.urlencode({'s': size, 'd': 'mm'})
             gravatar_url = getattr(settings, 'GRAVATAR_BASE_URL', 'https://secure.gravatar.com')
             avartar_url = '{0}/avatar/{1}?{2}'.format(gravatar_url, user_gravatar_id, params)


### PR DESCRIPTION
FIXES: #1063 

- migração para adicionar o campo tz (timezone) no perfil de usuário
- melhora na view do perfil do usuário
- ajustes em todos os templastes que tinham o filtro: ``|date:`` para aplicar a conversão para a timezone do usuário.
- fix template_tag: ``user_avatar_url`` na url do gravatar passava o email no lugar do hash.