### PR TITLE
#1075 - Monitor de Saúde para Celery e Rabbit

### DIFF
--- a/scielomanager/health/domain.py
+++ b/scielomanager/health/domain.py
@@ -18,7 +18,7 @@ class StatusChecker(object):
     """ Realiza e agrupa as verificações de saúde do sistema.
     """
     def __init__(self, client=health.Client):
-        self.client = client(timeout=1)
+        self.client = client(timeout=3)
 
     @property
     def is_fully_operational(self):

--- a/scielomanager/health/management/commands/healthd.py
+++ b/scielomanager/health/management/commands/healthd.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 def get_checklist():
     checklist = health.CheckList()
     checklist.add_check(checks.PGConnection())
+    checklist.add_check(checks.CeleryConnection())
+    checklist.add_check(checks.RabbitConnection())
 
     return checklist
 

--- a/scielomanager/health/templates/health/overall_status.html
+++ b/scielomanager/health/templates/health/overall_status.html
@@ -41,15 +41,18 @@
           </thead>
           <tbody>
             {% for service, status in statuses.items %}
-            <tr{% if not status.status %} class="error"{% endif %}>
+            <tr {% if status.status == None %} class="warning" {% elif not status.status %} class="error" {% endif %} >
               <td>{{ service }}</td>
               <td>{{ status.description }}</td>
               <td>
                 {% if status.status %}
                   {% trans "Operational" %}
+                {% elif status.status == None %}
+                  {% trans "Unknown" %}
                 {% else %}
                   {% trans "Offline" %}
                 {% endif %}
+
               </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
FIXES: #1075 

- healthd agora tem o timeout de 3 segundos.
- Para o caso de conexão com broker 'django://' o retorno dos CheckItem é None, representado no template como: "Unknown".