### PR TITLE
#1083 - Remover a capacidade de validar XMLs remotos

### DIFF
--- a/scielomanager/validator/forms.py
+++ b/scielomanager/validator/forms.py
@@ -5,21 +5,13 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 
 
-STYLECHECKER_TYPE_CHOICES = (
-    ('url', _('URL')),
-    ('file', _('File')),
-)
-
-
 class StyleCheckerForm(forms.Form):
-    type = forms.ChoiceField(label=_("Type"), choices=STYLECHECKER_TYPE_CHOICES, ) # widget=forms.RadioSelect
-    url = forms.URLField(label=_("URL"), required=False)
     file = forms.FileField(label=_("File"), required=False)
 
     def clean_file(self):
         _file = self.cleaned_data.get('file', None)
         if _file:
-            if _file.content_type not in ['text/xml', 'application/xml',]:
+            if _file.content_type not in ['text/xml', 'application/xml', ]:
                 raise forms.ValidationError(_(u"This type of file is not allowed! Please select another file."))
 
             if _file.size > settings.VALIDATOR_MAX_UPLOAD_SIZE:
@@ -28,12 +20,8 @@ class StyleCheckerForm(forms.Form):
         return _file
 
     def clean(self):
-        type = self.cleaned_data['type']
-        url = self.cleaned_data.get('url', None)
         file = self.cleaned_data.get('file', None)
 
-        if type == 'url' and not url:
-            raise forms.ValidationError('if trying to validate via URL, please submit a valid URL')
         if type == 'file' and not file:
             raise forms.ValidationError('if trying to validate a File, please upload a valid XML file')
 

--- a/scielomanager/validator/forms.py
+++ b/scielomanager/validator/forms.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext as _
 
 
 class StyleCheckerForm(forms.Form):
-    file = forms.FileField(label=_("File"), required=False)
+    file = forms.FileField(label=_("File"))
 
     def clean_file(self):
         _file = self.cleaned_data.get('file', None)

--- a/scielomanager/validator/forms.py
+++ b/scielomanager/validator/forms.py
@@ -18,11 +18,3 @@ class StyleCheckerForm(forms.Form):
                 raise forms.ValidationError(_(u"The file's size is too large! Please select a smaller file."))
 
         return _file
-
-    def clean(self):
-        file = self.cleaned_data.get('file', None)
-
-        if type == 'file' and not file:
-            raise forms.ValidationError('if trying to validate a File, please upload a valid XML file')
-
-        return self.cleaned_data

--- a/scielomanager/validator/templates/validator/packtools.html
+++ b/scielomanager/validator/templates/validator/packtools.html
@@ -26,7 +26,7 @@
       </p>
       <p>
       {% blocktrans %}
-      Enter the URL or browse to your local XML file and click "Validate". The results will be displayed below.
+      Browse to your local XML file and click "Validate". The results will be displayed below.
       {% endblocktrans %}
       </p>
 
@@ -35,11 +35,6 @@
 
         <ul class="nav nav-tabs">
           <li class="active">
-            <a href="#URL" data-toggle="tab">
-              <i class="icon-globe"></i> {% trans "Remote URL" %}
-            </a>
-          </li>
-          <li>
             <a href="#XML" data-toggle="tab">
               <i class="icon-upload"></i> {% trans "Upload XML" %}
             </a>
@@ -51,22 +46,7 @@
           </li>
         </ul>
         <div class="tab-content">
-          <div class="tab-pane active" id="URL">
-            {# URL FIELD #}
-            {% with form.url as field %}
-              <div class="control-group {% if field.errors|length > 0 %}error{% endif %}">
-                {{ field|attr:"class=span12"|attr:"placeholder=Insert a valid URL" }}
-
-                {# field errors #}
-                {% for error in field.errors %}
-                  <div class="alert alert-error">
-                    {{ error }}
-                  </div>
-                {% endfor %}
-              </div>
-            {% endwith %}
-          </div>
-          <div class="tab-pane" id="XML">
+          <div class="tab-pane active" id="XML">
             {# FILE FIELD #}
             {% with form.file as field %}
               <div class="control-group {% if field.errors|length > 0 %}error{% endif %}">
@@ -80,6 +60,11 @@
                 {% endfor %}
               </div>
             {% endwith %}
+
+            <div class='form-buttons clearfix'>
+              <input type="button" class="btn btn-danger pull-left" id='form_clear_btn' value="{% trans 'Clear' %}" />
+              <input type="submit" class="btn btn-success pull-right" value="{% trans 'Validate' %}" />
+            </div>
           </div>
           <div class="tab-pane" id="HELP">
             <div class="alert alert-info">
@@ -101,17 +86,6 @@
         <div id='form_messages' style='display:none;'>
           {# js validations messages goes here #}
         </div>
-
-        {# TYPE FIELD WILL BE HIDDEN only updated by JS #}
-        <div style='display:none'>
-          {{ form.type }}
-        </div>
-
-        <div class='form-buttons clearfix'>
-          <input type="button" class="btn btn-danger pull-left" id='form_clear_btn' value="{% trans 'Clear' %}" />
-          <input type="submit" class="btn btn-success pull-right" value="{% trans 'Validate' %}" />
-        </div>
-
       </form>
     </div>
   </div>
@@ -139,15 +113,8 @@
     $(function () {
       var stylechecker_form = $('#stylechecker');
       var form_buttons = $('.form-buttons', stylechecker_form);
-      var url_field = $('#id_url', stylechecker_form);
       var filestyle_field = $(":file", stylechecker_form);
       var selected_tab = null;
-
-      /* selet tab on load */
-      {% if form.type.value and form.type.value|lower == 'file' %}
-        $('a[href="#XML"]', stylechecker_form).tab('show');
-      {% endif %}
-
 
       function display_form_msg(msg, type, append){
         var form_messages = $('#form_messages');
@@ -166,80 +133,31 @@
         form_messages.show();
       }
 
-      function guess_selected_type(){
-        /*
-        first inspect "selected_tab" var if set to: XML or URL and the correct field with a value,
-        if none, then try:
-          - if url field have some value, then return "URL" as selected type.
-          - if file field have some value, then return "XML" as selected type.
-          - else: don't panic! simply return null as type.
-        */
-        var file_field = $('input', '.bootstrap-filestyle');
-
-        if (selected_tab == 'URL' && url_field.val() ) {
-          return 'URL'
-        } else if (selected_tab == 'FILE' && file_field.val()) {
-          return 'FILE'
-        } else {
-          /* no way to guess based on selected_tab */
-          if (url_field.val()) {
-            return 'URL';
-          }
-          if (file_field.val()) {
-            return 'FILE';
-          }
-          /* can't guess */
-          return null;
-        }
-      }
-
       /* resize button */
       filestyle_field.filestyle('classInput', 'span11 custom-filestyle');
 
       /* clear form */
       var clear_btn = $('#form_clear_btn', form_buttons);
       clear_btn.click(function(event){
-        url_field.val('');
         filestyle_field.filestyle('clear');
         $('#form_messages').html('');
       });
 
-      $('a[data-toggle="tab"]', stylechecker_form).on('shown', function (e) {
-        var target_url = e.target.href // activated tab
-        selected_tab = target_url.split('#')[1];
-        if (selected_tab !== 'XML' && selected_tab !== 'URL') {
-          form_buttons.hide();
-        } else {
-          form_buttons.show();
-        }
-      });
-
       /* control form submit */
       stylechecker_form.submit(function(){
-        /* update type_field value, based in selected tab */
-        var selected_type = guess_selected_type();
-        if (selected_type == 'URL' || selected_type == 'FILE') {
-          $('#id_type').val(selected_type.toLowerCase());
-        } else {
-          msg = "{% trans 'At least one field is required: URL or XML' %}";
-          display_form_msg(msg, 'error', true);
-          return false;
-        }
         /* validate XML size and content type */
-        if (selected_type == 'FILE') {
-          file_obj = $('#id_file')[0].files[0];
-          if (file_obj.type != "text/xml") {
-            msg = '{% trans "The file submitted is NOT XML" %}';
-            display_form_msg(msg, 'error', true);
-            return false
-          }
-          if (file_obj.size > {{ SETTINGS_MAX_UPLOAD_SIZE }}) {
-            msg = '{% trans "XML file excedes max upload size" %}';
-            display_form_msg(msg, 'error', true);
-            return false
-          }
-          return true;
+        file_obj = $('#id_file')[0].files[0];
+        if (file_obj.type != "text/xml") {
+          msg = '{% trans "The file submitted is NOT XML" %}';
+          display_form_msg(msg, 'error', true);
+          return false
         }
+        if (file_obj.size > {{ SETTINGS_MAX_UPLOAD_SIZE }}) {
+          msg = '{% trans "XML file excedes max upload size" %}';
+          display_form_msg(msg, 'error', true);
+          return false
+        }
+        return true;
 
       });
 

--- a/scielomanager/validator/tests/doubles.py
+++ b/scielomanager/validator/tests/doubles.py
@@ -36,15 +36,15 @@ class XMLValidatorAnnotationsDouble(XMLValidatorDouble):
             message = u'Premature end of data in tag xml line 1, line 1, column 6'
             level_name = 'ERROR'
 
-        for x in xrange(0,6):
+        for x in xrange(0, 6):
             error_list.append(DummyError())
 
         return False, error_list
 
 
-#------------------
+# ------------------
 # utils.analyze_xml
-#------------------
+# ------------------
 def make_stub_analyze_xml(type):
     """Factory for utils.analyze_xml stub functions.
 
@@ -80,4 +80,3 @@ def make_stub_analyze_xml(type):
         return result, err
 
     return stub__analyze_xml
-

--- a/scielomanager/validator/utils.py
+++ b/scielomanager/validator/utils.py
@@ -27,11 +27,12 @@ def make_error_filter(key):
     :param key: callable to get the filtering value
     """
     known_errors = set()
+
     def err_filter(err):
         _err = key(err)
 
         is_known = _err in known_errors
-        if is_known == False:
+        if is_known is False:
             known_errors.add(_err)
 
         return not is_known
@@ -51,8 +52,9 @@ def analyze_xml(file):
 
     else:
         status, errors = xml.validate_all()
-        err_xml = lxml.etree.tostring(xml.annotate_errors(),
-                pretty_print=True, encoding='utf-8', xml_declaration=True)
+        err_xml = lxml.etree.tostring(
+                    xml.annotate_errors(), pretty_print=True,
+                    encoding='utf-8', xml_declaration=True)
 
         result = {
             'annotations': err_xml,
@@ -68,4 +70,3 @@ def analyze_xml(file):
             result['validation_errors'] = err_list
 
     return result, err
-

--- a/scielomanager/validator/views.py
+++ b/scielomanager/validator/views.py
@@ -11,7 +11,7 @@ from . import utils
 @waffle_flag('packtools_validator')
 def packtools_home(request, template_name='validator/packtools.html'):
     context = {
-        'SETTINGS_MAX_UPLOAD_SIZE' : settings.VALIDATOR_MAX_UPLOAD_SIZE,
+        'SETTINGS_MAX_UPLOAD_SIZE': settings.VALIDATOR_MAX_UPLOAD_SIZE,
         'packtools_version': utils.PACKTOOLS_VERSION,
     }
 
@@ -19,11 +19,7 @@ def packtools_home(request, template_name='validator/packtools.html'):
     if request.method == 'POST':
         form = forms.StyleCheckerForm(request.POST, request.FILES)
         if form.is_valid():
-            type = form.cleaned_data['type']
-            if type == 'url':
-                xml_file = form.cleaned_data['url']
-            else:
-                xml_file = request.FILES['file']
+            xml_file = request.FILES['file']
 
             results, exc = utils.analyze_xml(xml_file)
             context['results'] = results


### PR DESCRIPTION
FIX: #1083 

#### Qual é o objetivo deste  PR:
Remover a capacidade de validar XMLs remotos, deixando habilitado somente a validação de arquivos locais XMLs
  
#### Por onde deveria começar a revisão:
- usando o formulário de validação:  ``http://127.0.0.1:8000/tools/validators/stylechecker/``
- pelo arquivo: ``scielomanager/validator/forms.py``

#### Por onde deveria começar os tests manuais?
- test o formulário de validação:  http://127.0.0.1:8000/tools/validators/stylechecker/
- executando os tests unitários: 
```python
python manage.py test validator.tests.tests_pages.ValidatorTests  --settings= scielomanager.settings_tests
```

#### issues relevantes?
- #1083 
