### PR TITLE
Permitir configurações externas ao pacote da app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
   - 2.7
-services: 
-  - mongodb
 env:
   - DJANGO_VERSION=1.4
+  - SCIELOMANAGER_SETTINGS_FILE=`pwd`/scielomanager/scielomanager/settings_local.include
 install:
   - pip install -r requirements.txt --use-mirrors
   - pip install -r requirements-test.txt --use-mirrors

--- a/scielomanager/scielomanager/settings.py
+++ b/scielomanager/scielomanager/settings.py
@@ -312,14 +312,18 @@ CHECKIN_EXPIRATION_TIME_SPAN = 7  # days
 #################################################################
 
 # Local deployment settings: there *must* be an unversioned
-# 'settings_local.include' file in the current directory.
+# 'scielomanager.conf' file in /etc/scieloapps/.
 # See sample file at settings_local-SAMPLE.include.
 # NOTE: in the next line we do not use a simple...
 # try: from settings_local import * except ImportError: pass
 # ...because (1) we want to be able to add to settings in this file, and
 # not only overwrite them, and (2) we do not want the app to launch if the
-# 'settings_local.include' file is not provided
-execfile(os.path.join(HERE, 'settings_local.include'))
+# config file cannot be loaded.
+SCIELOMANAGER_SETTINGS_FILE = os.environ.get('SCIELOMANAGER_SETTINGS_FILE')
+if SCIELOMANAGER_SETTINGS_FILE:
+    execfile(SCIELOMANAGER_SETTINGS_FILE)
+else:
+    raise RuntimeError('Missing settings file. Make sure SCIELOMANAGER_SETTINGS_FILE is configured.')
 
 # Always minify the HTML when the DEBUG mode is False
 HTML_MINIFY = not DEBUG


### PR DESCRIPTION
O arquivo de configurações deve ser declarado por meio da variável de
ambiente SCIELOMANAGER_SETTINGS_FILE. A ausência dessa variável
levantará um RuntimeError.

Idealmente, o arquivo de configuração deve ser alocado fora da estrutura
do pacote da aplicação, apenas com permissão de leitura.