### PR TITLE
Task *compile* no Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ compilemessages:
 
 compile: 
 	@echo "Compiling all source files..."
-	@cd $(APP_PATH) && for PYMOD in $$(find . -name '*.py'); do python -m compileall $$PYMOD; done
+	@cd $(APP_PATH) && python -m compileall .
 
 setup: clean compile deps dbsetup dbmigrate loaddata compilemessages test 
 


### PR DESCRIPTION
Task que compila todos os módulos do projeto. O objetivo é de tornar
explícita a etapa de compilação, para que seja realizada por um usuário
com privilégios administrativos, e não mais pelo servidor de aplicação.

Outros ajustes foram realizados no Makefile para reduzir efeitos
colaterais, como por exemplo a execução da task "clean".