### PR TITLE
removendo waffle: 'packtools_validator'

### DIFF
--- a/scielomanager/scielomanager/templates/footer.html
+++ b/scielomanager/scielomanager/templates/footer.html
@@ -30,14 +30,12 @@
     </ul>
   </div>
   <div class="span2">
-    {% flag 'packtools_validator' %}
     <h4>{% trans "Tools" %}</h4>
     <ul>
       <li>
         <a href="{% url validator.packtools.stylechecker %}">{% trans "Packtools StyleChecker" %}</a>
       </li>
     </ul>
-    {% endflag %}
   </div>
   <div class="span2">
     <form name="form_language" id="form_language" action="/i18n/setlang/" method="post">

--- a/scielomanager/validator/tests/tests_pages.py
+++ b/scielomanager/validator/tests/tests_pages.py
@@ -11,8 +11,6 @@ from django.conf import settings
 from django_factory_boy import auth
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
-from waffle import Flag
-
 from . import doubles
 import pkg_resources
 
@@ -59,22 +57,7 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
     def _addWaffleFlag(self):
         Flag.objects.create(name='packtools_validator', everyone=True)
 
-    def test_status_code_stylechecker_without_waffle_flag(self):
-        response = self.app.get(
-            reverse('validator.packtools.stylechecker',),
-            expect_errors=True
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_status_code_stylechecker_with_waffle_flag(self):
-        self._addWaffleFlag()
-        response = self.app.get(
-            reverse('validator.packtools.stylechecker',),
-        )
-        self.assertEqual(response.status_code, 200)
-
     def test_access_unauthenticated_user(self):
-        self._addWaffleFlag()
         response = self.app.get(
             reverse('validator.packtools.stylechecker',),
         )
@@ -82,7 +65,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
         self.assertTemplateUsed(response, 'validator/packtools.html')
 
     def test_access_authenticated_user(self):
-        self._addWaffleFlag()
         self.user = auth.UserF(is_active=True)
         response = self.app.get(
             reverse('validator.packtools.stylechecker',),
@@ -92,7 +74,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
         self.assertTemplateUsed(response, 'validator/packtools.html')
 
     def test_link_is_present_at_homepage(self):
-        self._addWaffleFlag()
         response = self.app.get(
             reverse('index',),
         )
@@ -106,7 +87,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
 
     def test_submit_empty_form_is_not_valid(self):
         # with
-        self._addWaffleFlag()
         page = self.app.get(
             reverse('validator.packtools.stylechecker',),
         )
@@ -126,7 +106,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
         Submitting a text file will raise a from validation error
         """
         # with
-        self._addWaffleFlag()
         test_file = get_temporary_text_file()
         # when
         response = self.client.post(
@@ -148,7 +127,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
         Submitting a image file will raise a from validation error
         """
         # with
-        self._addWaffleFlag()
         test_file = get_temporary_image_file()
         # when
         response = self.client.post(
@@ -169,7 +147,6 @@ class ValidatorTests(WebTest, mocker.MockerTestCase):
         and xml validation will return annotations
         """
         # with
-        self._addWaffleFlag()
 
         stub_analyze_xml = doubles.make_stub_analyze_xml('valid')
         mock_utils = self.mocker.replace('validator.utils')

--- a/scielomanager/validator/views.py
+++ b/scielomanager/validator/views.py
@@ -2,13 +2,11 @@
 from django.template.context import RequestContext
 from django.shortcuts import render_to_response
 from django.conf import settings
-from waffle.decorators import waffle_flag
 
 from . import forms
 from . import utils
 
 
-@waffle_flag('packtools_validator')
 def packtools_home(request, template_name='validator/packtools.html'):
     context = {
         'SETTINGS_MAX_UPLOAD_SIZE': settings.VALIDATOR_MAX_UPLOAD_SIZE,


### PR DESCRIPTION
#### Objetivo do PR?
Remover o waffle: 'packtools_validator' das views/templates e tests relacionados. Porque não é mais necessário.

#### Por onde deve começar a revisão?
- vistas aonde é utilizado o waffle: ``scielomanager/validator/views.py``
- templates que utilizem o waffle: `` scielomanager/scielomanager/templates/footer.html``

#### Como poderia fazer um test manual:
- cada acesso na página gerava uma query SQL consultando pelo waffle, agora não deve aparecer  mais. Isso pode ser comprovado com a app Django-Debug-Toolbar.
- o acesso e a utliização do validador: StyleChecker deve ser normal.

#### Tickets Relacionados:
FIX: #1098 

#### Screenshots
Antes de remover (8 queries):
![screenshot 2015-05-19 16 32 33](https://cloud.githubusercontent.com/assets/805749/7751320/a4e8d962-ffaf-11e4-941e-9bcd1f781ce4.png)

Depois de remover (7 queries):
![screenshot 2015-05-21 11 48 57](https://cloud.githubusercontent.com/assets/805749/7751331/b198b042-ffaf-11e4-96ba-3b7d779dc521.png)

