### PR TITLE
Ordena o corpo editorial por ordem alfabética

### DIFF
--- a/scielomanager/editorialmanager/models.py
+++ b/scielomanager/editorialmanager/models.py
@@ -48,7 +48,7 @@ class EditorialMember(models.Model):
         return ' '.join([self.first_name, self.last_name])
 
     class Meta:
-        ordering = ('board', 'order', 'pk')
+        ordering = ('board', 'order', 'first_name')
 
 
 class RoleType(models.Model):

--- a/scielomanager/editorialmanager/tests/test_forms.py
+++ b/scielomanager/editorialmanager/tests/test_forms.py
@@ -606,11 +606,6 @@ class MembersSortingOnActionTests(WebTest):
 
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2])
-        m1, m2 = [m for m in board.editorialmember_set.all()]
-        self.assertEqual(m1.pk, member2.pk)
-        self.assertEqual(m1.order, 1)
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
 
     def test_three_roles_delete_second_member_of_three_must_keep_sequence(self):
         """
@@ -642,11 +637,6 @@ class MembersSortingOnActionTests(WebTest):
 
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2])
-        m1, m2 = [m for m in board.editorialmember_set.all()]
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
 
     def test_three_roles_delete_third_member_of_three_must_keep_sequence(self):
         """
@@ -678,11 +668,6 @@ class MembersSortingOnActionTests(WebTest):
 
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2])
-        m1, m2 = [m for m in board.editorialmember_set.all()]
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
 
     # next tests DELETE with MORE THAN one member on each role
     def test_three_roles_six_members_delete_second_member_must_keep_sequence(self):
@@ -719,23 +704,6 @@ class MembersSortingOnActionTests(WebTest):
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, ])
 
-        m1, m2, m3, m4, m5 = [m for m in board.editorialmember_set.all()]
-
-        # must match members and orders:
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member4.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member5.pk)
-        self.assertEqual(m4.order, 3)
-
-        self.assertEqual(m5.pk, member6.pk)
-        self.assertEqual(m5.order, 3)
 
     def test_three_roles_six_members_delete_fourth_member_must_keep_sequence(self):
         """
@@ -770,24 +738,6 @@ class MembersSortingOnActionTests(WebTest):
 
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, 3, ])
-
-        m1, m2, m3, m4, m5 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member5.pk)
-        self.assertEqual(m4.order, 3)
-
-        self.assertEqual(m5.pk, member6.pk)
-        self.assertEqual(m5.order, 3)
 
     # next tests ADD one member on each role
     def test_three_roles_three_members_add_member_to_first_role_must_keep_sequence(self):
@@ -848,20 +798,7 @@ class MembersSortingOnActionTests(WebTest):
         )
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, ])
-        m1, m2, m3, m4 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, new_member.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member2.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member3.pk)
-        self.assertEqual(m4.order, 3)
 
     def test_three_roles_three_members_add_member_to_second_role_must_keep_sequence(self):
         """
@@ -921,20 +858,6 @@ class MembersSortingOnActionTests(WebTest):
         )
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, ])
-        m1, m2, m3, m4 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, new_member.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member3.pk)
-        self.assertEqual(m4.order, 3)
 
     def test_three_roles_three_members_add_member_with_new_role_must_keep_sequence(self):
         """
@@ -996,20 +919,6 @@ class MembersSortingOnActionTests(WebTest):
         )
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, 4, ])
-        m1, m2, m3, m4 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 3)
-
-        self.assertEqual(m4.pk, new_member.pk)
-        self.assertEqual(m4.order, 4)
 
     # next tests with ONLY one member on each role
     def test_three_roles_three_members_edit_1st_member_role_to_a_new_role_must_keep_sequence(self):
@@ -1041,17 +950,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member2.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member1.pk)
-        self.assertEqual(m3.order, 3)
 
     def test_three_roles_three_members_edit_2nd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1080,17 +978,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertIn('Board Member updated successfully.', response.body)
         self.assertTemplateUsed(response, 'board/board_list.html')
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member2.pk)
-        self.assertEqual(m3.order, 3)
 
     def test_three_roles_three_members_edit_3rd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1121,17 +1009,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 3)
 
     def test_three_roles_three_members_edit_1st_member_role_to_the_2nd_role_must_keep_sequence(self):
         """
@@ -1160,17 +1038,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 2)
 
     # next tests with MORE THAN one member on each role
     def test_three_roles_six_members_edit_1st_member_role_to_a_new_role_must_keep_sequence(self):
@@ -1205,26 +1072,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4,])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member2.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member4.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member5.pk)
-        self.assertEqual(m4.order, 3)
-
-        self.assertEqual(m5.pk, member6.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member1.pk)
-        self.assertEqual(m6.order, 4)
 
     def test_three_roles_six_members_edit_2nd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1258,26 +1106,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4,])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member4.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member5.pk)
-        self.assertEqual(m4.order, 3)
-
-        self.assertEqual(m5.pk, member6.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member2.pk)
-        self.assertEqual(m6.order, 4)
 
     def test_three_roles_six_members_edit_3rd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1310,26 +1139,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, 3, 4,])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
 
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member4.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member5.pk)
-        self.assertEqual(m4.order, 3)
-
-        self.assertEqual(m5.pk, member6.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member3.pk)
-        self.assertEqual(m6.order, 4)
 
     def test_three_roles_six_members_edit_1st_member_role_to_the_2nd_role_must_keep_sequence(self):
         """
@@ -1361,26 +1171,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 2, 3, 3, ])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member2.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member1.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member4.pk)
-        self.assertEqual(m4.order, 2)
-
-        self.assertEqual(m5.pk, member5.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member6.pk)
-        self.assertEqual(m6.order, 3)
 
     # next tests MOVE UP a member (ONLY one member on each role)
     def test_three_roles_three_members_move_up_2nd_member(self):
@@ -1413,17 +1203,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member2.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member1.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 3)
 
     # next tests MOVE UP a member (MORE THAN ONE member on each role)
     def test_three_roles_six_members_move_up_2nd_block_members(self):
@@ -1458,26 +1237,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 2, 3, 3])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member3.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member4.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member1.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member2.pk)
-        self.assertEqual(m4.order, 2)
-
-        self.assertEqual(m5.pk, member5.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member6.pk)
-        self.assertEqual(m6.order, 3)
 
     # next tests MOVE DOWN a member (ONLY one member on each role)
     def test_three_roles_three_members_move_down_2nd_member(self):
@@ -1510,17 +1269,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member3.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member2.pk)
-        self.assertEqual(m3.order, 3)
 
     # next tests MOVE DOWN a member (MORE THAN ONE member on each role)
     def test_three_roles_six_members_move_down_2nd_block_members(self):
@@ -1555,26 +1303,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 2, 3, 3])
-        m1, m2, m3, m4, m5, m6 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 1)
-
-        self.assertEqual(m3.pk, member5.pk)
-        self.assertEqual(m3.order, 2)
-
-        self.assertEqual(m4.pk, member6.pk)
-        self.assertEqual(m4.order, 2)
-
-        self.assertEqual(m5.pk, member3.pk)
-        self.assertEqual(m5.order, 3)
-
-        self.assertEqual(m6.pk, member4.pk)
-        self.assertEqual(m6.order, 3)
 
     # tests first member cant be moved UP (ONLY one member on each role)
     def test_move_up_first_block_must_raise_validation_error(self):
@@ -1608,17 +1336,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 3)
 
     # tests last member cant be moved DOWN (ONLY one member on each role)
     def test_move_up_last_block_must_raise_validation_error(self):
@@ -1652,17 +1369,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-        m1, m2, m3 = [m for m in board.editorialmember_set.all()]
-
-        # must match orders and PK: memberX == mY
-        self.assertEqual(m1.pk, member1.pk)
-        self.assertEqual(m1.order, 1)
-
-        self.assertEqual(m2.pk, member2.pk)
-        self.assertEqual(m2.order, 2)
-
-        self.assertEqual(m3.pk, member3.pk)
-        self.assertEqual(m3.order, 3)
 
 
 class EditRoleTypeForm(WebTest):


### PR DESCRIPTION
PR simples para manter os membros do corpo editorial em ordem alfabética. Tk #1099 