### PR TITLE
Fixes #1126 - Corrige falha na associação entre artigos e periódicos.

### DIFF
--- a/scielomanager/journalmanager/tasks.py
+++ b/scielomanager/journalmanager/tasks.py
@@ -149,8 +149,13 @@ def link_article_to_journal(article_pk):
         journal = models.Journal.objects.get(
                 Q(print_issn=article.issn_ppub) | Q(eletronic_issn=article.issn_epub))
     except models.Journal.DoesNotExist:
-        logger.info('Cannot find parent Journal for Article with pk: %s. Skipping the linking task.', article_pk)
-        return None
+        # Pode ser que os ISSNs do XML estejam invertidos...
+        try:
+            journal = models.Journal.objects.get(
+                    Q(print_issn=article.issn_epub) | Q(eletronic_issn=article.issn_ppub))
+        except models.Journal.DoesNotExist:
+            logger.info('Cannot find parent Journal for Article with pk: %s. Skipping the linking task.', article_pk)
+            return None
 
     article.journal = journal
     with avoid_circular_signals(ARTICLE_SAVE_MUTEX):


### PR DESCRIPTION
Em levantamento realizado em todos os XMLs SPS da Revista de Saúde Pública,
10% apresentam inversão na identificação do ISSN impresso, e 12% na
identificação do ISSN eletrônico. Também foram levantados dados da ABEM
e ABC, entretanto nenhuma apresentou a inversão.

Por tratar-se então de uma condição excepcional, a tentativa de
associação de XMLs que contém a inversão será realizada apenas caso a
primeira tentativa falhe, onerando assim apenas os casos excepcionais
com maior custo de consulta ao banco de dados.