### PR TITLE
Remover Waffle 'editorialmanager'

### DIFF
--- a/scielomanager/editorialmanager/tests/test_forms.py
+++ b/scielomanager/editorialmanager/tests/test_forms.py
@@ -243,13 +243,13 @@ class EditorialMemberFormAsEditorTests(WebTest):
         audit_entries = AuditLogEntry.objects.all()
         self.assertEqual(audit_entries.count(), 1)
         entry = audit_entries[0]
-        self.assertEqual(entry.action_flag, ADDITION) # Flag correspond with ADDITION action
+        self.assertEqual(entry.action_flag, ADDITION)  # Flag correspond with ADDITION action
         self.assertEqual(entry.content_type.model_class(), EditorialMember)
         audited_obj = entry.get_audited_object()
         self.assertEqual(audited_obj._meta.object_name, 'EditorialMember')
         self.assertEqual(audited_obj.pk, members[0].pk)
 
-        self.assertIn(u'Added fields:', entry.change_message) # message starts with u'Added fields:'
+        self.assertIn(u'Added fields:', entry.change_message)  # message starts with u'Added fields:'
         for field_name in member_data.keys():
             self.assertIn(field_name, entry.change_message)
 
@@ -491,10 +491,10 @@ class EditorialMemberFormAsEditorTests(WebTest):
         audit_entries = AuditLogEntry.objects.all()
         self.assertEqual(audit_entries.count(), 1)
         entry = audit_entries[0]
-        self.assertEqual(entry.action_flag, DELETION) # Flag correspond with DELETE action
+        self.assertEqual(entry.action_flag, DELETION)  # Flag correspond with DELETE action
         self.assertEqual(entry.content_type.model_class(), EditorialMember)
         audited_obj = entry.get_audited_object()
-        self.assertIsNone(audited_obj) # audited object (member) was deleted, so, no referece to it
+        self.assertIsNone(audited_obj)  # audited object (member) was deleted, so, no referece to it
         expected_change_msg = u'Record DELETED (%s, pk: %s): %s' % (member.pk, member._meta.verbose_name, unicode(member))
         self.assertEqual(entry.change_message, expected_change_msg)
 
@@ -695,7 +695,6 @@ class MembersSortingOnActionTests(WebTest):
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, ])
 
-
     def test_three_roles_six_members_delete_fourth_member_must_keep_sequence(self):
         """
         Create 6 board members, 3 pairs with 3 different roles. [a1(1), a2(1), a3(2), a4(2), a5(3), a6(3), ]
@@ -789,7 +788,6 @@ class MembersSortingOnActionTests(WebTest):
         )
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, ])
-
 
     def test_three_roles_three_members_add_member_to_second_role_must_keep_sequence(self):
         """
@@ -970,7 +968,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
 
-
     def test_three_roles_three_members_edit_3rd_member_role_to_a_new_role_must_keep_sequence(self):
         """
         Create 3 board members, each one with different roles. (a1, a2, a3,)
@@ -1000,7 +997,6 @@ class MembersSortingOnActionTests(WebTest):
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
         self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 3, ])
-
 
     def test_three_roles_three_members_edit_1st_member_role_to_the_2nd_role_must_keep_sequence(self):
         """
@@ -1062,8 +1058,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertIn('Board Member updated successfully.', response.body)
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
-        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4,])
-
+        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4, ])
 
     def test_three_roles_six_members_edit_2nd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1096,8 +1091,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertIn('Board Member updated successfully.', response.body)
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
-        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4,])
-
+        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 2, 2, 3, 3, 4, ])
 
     def test_three_roles_six_members_edit_3rd_member_role_to_a_new_role_must_keep_sequence(self):
         """
@@ -1129,8 +1123,7 @@ class MembersSortingOnActionTests(WebTest):
         self.assertIn('Board Member updated successfully.', response.body)
         self.assertTemplateUsed(response, 'board/board_list.html')
         # check the order of the board members
-        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, 3, 4,])
-
+        self.assertEqual([m.order for m in board.editorialmember_set.all()], [1, 1, 2, 3, 3, 4, ])
 
     def test_three_roles_six_members_edit_1st_member_role_to_the_2nd_role_must_keep_sequence(self):
         """
@@ -1415,7 +1408,7 @@ class EditRoleTypeForm(WebTest):
         audit_entries = AuditLogEntry.objects.all()
         self.assertEqual(audit_entries.count(), 1)
         entry = audit_entries[0]
-        self.assertEqual(entry.action_flag, ADDITION) # Flag correspond with ADD action
+        self.assertEqual(entry.action_flag, ADDITION)  # Flag correspond with ADD action
         self.assertEqual(entry.content_type.model_class(), RoleType)
         audited_obj = entry.get_audited_object()
         self.assertEqual(audited_obj._meta.object_name, 'RoleType')
@@ -1431,7 +1424,7 @@ class EditRoleTypeForm(WebTest):
         pre_submittion_audit_logs_count = AuditLogEntry.objects.all().count()
         # when
         response = self.app.get(reverse("editorial.role.add", args=[self.journal.id]), user=self.user)
-        new_role_name = "" # empty name for a mandatory field is invalid
+        new_role_name = ""  # empty name for a mandatory field is invalid
         # when
         form = response.forms['role-form']
         form['name'] = new_role_name
@@ -1488,8 +1481,6 @@ class EditRoleTypeForm(WebTest):
         self.assertEqual(pre_submittion_audit_logs_count, 0)
         self.assertEqual(AuditLogEntry.objects.all().count(), 0)
 
-
-
     def test_EDIT_ROLE_valid_POST_is_valid(self):
         # with
         board = EditorialBoard.objects.create(issue=self.issue)
@@ -1518,7 +1509,7 @@ class EditRoleTypeForm(WebTest):
         audit_entries = AuditLogEntry.objects.all()
         self.assertEqual(audit_entries.count(), 1)
         entry = audit_entries[0]
-        self.assertEqual(entry.action_flag, CHANGE) # Flag correspond with ADD action
+        self.assertEqual(entry.action_flag, CHANGE)  # Flag correspond with ADD action
         self.assertEqual(entry.content_type.model_class(), RoleType)
         audited_obj = entry.get_audited_object()
         self.assertEqual(audited_obj._meta.object_name, 'RoleType')
@@ -1581,7 +1572,7 @@ class EditRoleTypeForm(WebTest):
         # when
         response = self.app.get(reverse("editorial.role.translate", args=[self.journal.id, role.id]), user=self.user)
         form = response.forms['role-translations-form']
-        for x in xrange(0,3):
+        for x in xrange(0, 3):
             form['role-translations-formset-%s-name' % x] = data[x]['name']
             form.set('role-translations-formset-%s-language' % x, data[x]['language'].pk)
 
@@ -1594,7 +1585,7 @@ class EditRoleTypeForm(WebTest):
         # check db:
         translations = RoleTypeTranslation.objects.filter(role=role)
         self.assertEqual(translations.count(), 3)
-        for x in xrange(0,3):
+        for x in xrange(0, 3):
             t = translations.get(language=data[x]['language'])
             self.assertEqual(t.name, data[x]['name'])
 
@@ -1603,7 +1594,7 @@ class EditRoleTypeForm(WebTest):
         audit_entries = AuditLogEntry.objects.all()
         self.assertEqual(audit_entries.count(), 1)
         entry = audit_entries[0]
-        self.assertEqual(entry.action_flag, CHANGE) # Flag correspond with ADD action
+        self.assertEqual(entry.action_flag, CHANGE)  # Flag correspond with ADD action
         self.assertEqual(entry.content_type.model_class(), RoleType)
         audited_obj = entry.get_audited_object()
         self.assertEqual(audited_obj._meta.object_name, 'RoleType')
@@ -1634,7 +1625,7 @@ class EditRoleTypeForm(WebTest):
         # when
         response = self.app.get(reverse("editorial.role.translate", args=[self.journal.id, role.id]), user=self.user)
         form = response.forms['role-translations-form']
-        for x in xrange(0,3):
+        for x in xrange(0, 3):
             form['role-translations-formset-%s-name' % x] = data[x]['name']
             form.set('role-translations-formset-%s-language' % x, data[x]['language'].pk)
 
@@ -1676,7 +1667,7 @@ class EditRoleTypeForm(WebTest):
         # when
         response = self.app.get(reverse("editorial.role.translate", args=[self.journal.id, role.id]), user=self.user)
         form = response.forms['role-translations-form']
-        for x in xrange(0,3):
+        for x in xrange(0, 3):
             form['role-translations-formset-%s-name' % x] = data[x]['name']
             form.set('role-translations-formset-%s-language' % x, data[x]['language'].pk)
 

--- a/scielomanager/editorialmanager/tests/test_pages.py
+++ b/scielomanager/editorialmanager/tests/test_pages.py
@@ -123,7 +123,7 @@ class PagesAsEditorTests(WebTest):
         # then
 
         # have no link to ADD, EDIT or DELETE a board member
-        self.assertNotIn(delete_url,response.body)
+        self.assertNotIn(delete_url, response.body)
 
         # when gain permission to DELETE editorial member, the link is shown
         _set_permission_to_group('delete_editorialmember', self.group)
@@ -283,7 +283,7 @@ class RoleType(WebTest):
         User must have the permission: editorialmanager.add_roletype to see the button
         """
         # when
-        response = self.app.get(reverse("editorial.board", args=[self.journal.id,]), user=self.user)
+        response = self.app.get(reverse("editorial.board", args=[self.journal.id, ]), user=self.user)
 
         # then
         self.assertEqual(response.status_code, 200)
@@ -299,7 +299,7 @@ class RoleType(WebTest):
         perm_add_roletype = _makePermission(perm='add_roletype', model='roletype')
         self.user.user_permissions.add(perm_add_roletype)
         # when
-        response = self.app.get(reverse("editorial.board", args=[self.journal.id,]), user=self.user)
+        response = self.app.get(reverse("editorial.board", args=[self.journal.id, ]), user=self.user)
 
         # then
         self.assertEqual(response.status_code, 200)
@@ -356,7 +356,7 @@ class RoleType(WebTest):
         # then
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'board/board_list.html')
-        list_role_url = reverse("editorial.role.list", args=[self.journal.id,])
+        list_role_url = reverse("editorial.role.list", args=[self.journal.id, ])
         self.assertIn(list_role_url, response.body)
 
     def test_access_to_EDIT_and_TRANSLATE_from_role_list_DISABLE(self):
@@ -367,7 +367,7 @@ class RoleType(WebTest):
         board = EditorialBoard.objects.create(issue=self.issue)
         role = editorial_modelfactories.RoleTypeFactory.create(name='blaus!!!')
         # when
-        response = self.app.get(reverse("editorial.role.list", args=[self.journal.id,]), user=self.user)
+        response = self.app.get(reverse("editorial.role.list", args=[self.journal.id, ]), user=self.user)
 
         # then
         self.assertEqual(response.status_code, 200)
@@ -390,7 +390,7 @@ class RoleType(WebTest):
         perm_change_roletype = _makePermission(perm='change_roletype', model='roletype')
         self.user.user_permissions.add(perm_change_roletype)
         # when
-        response = self.app.get(reverse("editorial.role.list", args=[self.journal.id,]), user=self.user)
+        response = self.app.get(reverse("editorial.role.list", args=[self.journal.id, ]), user=self.user)
 
         # then
         self.assertEqual(response.status_code, 200)

--- a/scielomanager/journalmanager/templates/journalmanager/add_user.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_user.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 {% load pagination_tags %}
-{% load waffle_tags %}
 
 {% block messages %}
   {% if add_form.errors %}

--- a/scielomanager/journalmanager/templates/journalmanager/inctag_journaldash_toolbar.html
+++ b/scielomanager/journalmanager/templates/journalmanager/inctag_journaldash_toolbar.html
@@ -28,16 +28,14 @@
           <a href="{% url journal_status.edit journal_id %}">{% trans 'Status' %}</a>
         </li>
         {% endif %}
-        {% flag 'editorialmanager' %}
-          {% if perms.journalmanager.change_editor %}
-            <li {% if page == 'editor' %}class="active activedash" {% endif %}>
-              <a href="{% url editor.index journal_id %}">{% trans 'Editor' %}</a>
-            </li>
-          {% endif %}
-          <li {% if page == 'editorial_board' %}class="active activedash" {% endif %}>
-            <a href="{% url editorial.board journal_id %}">{% trans 'Board' %}</a>
+        {% if perms.journalmanager.change_editor %}
+          <li {% if page == 'editor' %}class="active activedash" {% endif %}>
+            <a href="{% url editor.index journal_id %}">{% trans 'Editor' %}</a>
           </li>
-        {% endflag %}
+        {% endif %}
+        <li {% if page == 'editorial_board' %}class="active activedash" {% endif %}>
+          <a href="{% url editorial.board journal_id %}">{% trans 'Board' %}</a>
+        </li>
       </ul>
     </div>
   </div>

--- a/scielomanager/journalmanager/templates/journalmanager/inctag_journaldash_toolbar.html
+++ b/scielomanager/journalmanager/templates/journalmanager/inctag_journaldash_toolbar.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load waffle_tags %}
 
 {% if journal_id %}
   <div class="navbar">

--- a/scielomanager/journalmanager/tests/tests_forms.py
+++ b/scielomanager/journalmanager/tests/tests_forms.py
@@ -12,7 +12,6 @@ from django.test import TestCase
 from django.forms.models import inlineformset_factory
 from django.contrib.auth.models import User
 from django.test.utils import override_settings
-from waffle import Flag
 
 from journalmanager.tests import modelfactories
 from editorialmanager.tests.modelfactories import EditorialBoardFactory, EditorialMemberFactory
@@ -828,7 +827,7 @@ class UserFormTests(WebTest):
             'first_name': 'foo',
             'last_name': 'bar',
             'email': 'bazz@spam.org',
-            'email_notifications':  False, # email notifications must be unchecked
+            'email_notifications':  False,  # email notifications must be unchecked
         }
         perm = _makePermission(perm='change_user', model='user', app_label='auth')
         self.user.user_permissions.add(perm)
@@ -1758,8 +1757,7 @@ class JournalFormTests(WebTest):
         response = form.submit().follow()
 
         self.assertIn('Saved.', response.body)
-        self.assertIn('ABCD.(São Paulo)',
-            response.body)
+        self.assertIn('ABCD.(São Paulo)', response.body)
         self.assertTemplateUsed(response, 'journalmanager/journal_dash.html')
 
     def test_user_add_journal_but_this_journal_already_exists(self):
@@ -2010,8 +2008,7 @@ class SponsorFormTests(WebTest):
 
         response = form.submit().follow()
 
-        self.assertTemplateUsed(response,
-            'journalmanager/sponsor_list.html')
+        self.assertTemplateUsed(response, 'journalmanager/sponsor_list.html')
         self.assertIn('Saved.', response.body)
         self.assertIn('Funda\xc3\xa7\xc3\xa3o de Amparo a Pesquisa do Estado de S\xc3\xa3o Paulo', response.body)
 
@@ -2157,7 +2154,6 @@ class IssueBaseFormClassTests(unittest.TestCase):
             'cover': '',
         }
 
-
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
                                             querysets={
@@ -2201,7 +2197,6 @@ class IssueBaseFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
@@ -2247,7 +2242,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'cover': '',
         }
 
-
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
                                             querysets={
@@ -2276,7 +2270,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
@@ -2307,7 +2300,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'cover': '',
         }
 
-
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
                                             querysets={
@@ -2336,7 +2328,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
@@ -2367,7 +2358,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
@@ -2402,7 +2392,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'cover': '',
         }
 
-
         issue_form = forms.RegularIssueForm(POST,
                                             params={'journal': journal},
                                             querysets={
@@ -2433,7 +2422,6 @@ class RegularIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.RegularIssueForm(POST,
                                             instance=issue,
@@ -2470,7 +2458,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum',
-            'suppl_type' : 'volume',
+            'suppl_type': 'volume',
             'volume': '1',
             'number': '',
             'publication_start_month': '1',
@@ -2483,7 +2471,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2502,7 +2489,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum',
-            'suppl_type' : 'number',
+            'suppl_type': 'number',
             'volume': '',
             'number': '1',
             'publication_start_month': '1',
@@ -2515,7 +2502,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2534,7 +2520,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum',
-            'suppl_type' : 'number',
+            'suppl_type': 'number',
             'volume': '1',
             'number': '1',
             'publication_start_month': '1',
@@ -2547,7 +2533,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2566,7 +2551,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'suppl_type' : 'volume',
+            'suppl_type': 'volume',
             'volume': '1',
             'number': '1',
             'publication_start_month': '1',
@@ -2579,7 +2564,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2598,7 +2582,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'suppl_type' : 'number',
+            'suppl_type': 'number',
             'volume': '1',
             'number': '',
             'publication_start_month': '1',
@@ -2611,7 +2595,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2630,7 +2613,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'suppl_type' : 'number',
+            'suppl_type': 'number',
             'volume': '1',
             'number': '',
             'publication_start_month': '1',
@@ -2643,7 +2626,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2662,7 +2644,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'suppl_type' : 'number',
+            'suppl_type': 'number',
             'volume': '',
             'number': '',
             'publication_start_month': '1',
@@ -2675,7 +2657,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2694,7 +2675,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'suppl_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'suppl_type' : 'volume',
+            'suppl_type': 'volume',
             'volume': '',
             'number': '',
             'publication_start_month': '1',
@@ -2707,7 +2688,6 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'editorial_standard': 'iso690',
             'cover': '',
         }
-
 
         issue_form = forms.SupplementIssueForm(POST,
                                             params={'journal': journal},
@@ -2739,7 +2719,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'section': [section.pk],
             'volume': issue.volume,
             'number': issue.number,
-            'suppl_type':'number',
+            'suppl_type': 'number',
             'suppl_text': issue.suppl_text,
             'publication_start_month': '1',
             'publication_end_month': '2',
@@ -2782,7 +2762,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'section': [section.pk],
             'volume': issue.volume,
             'number': issue.number,
-            'suppl_type':'volume',
+            'suppl_type': 'volume',
             'suppl_text': issue.suppl_text,
             'publication_start_month': '1',
             'publication_end_month': '2',
@@ -2883,7 +2863,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'section': [section.pk],
             'volume': issue.volume,
             'number': issue.number,
-            'suppl_type':issue.suppl_type,
+            'suppl_type': issue.suppl_type,
             'suppl_text': issue.suppl_text,
             'publication_start_month': '2',
             'publication_end_month': '2',
@@ -2921,7 +2901,7 @@ class SupplementIssueFormClassTests(unittest.TestCase):
             'section': [section.pk],
             'volume': issue.volume,
             'number': issue.number,
-            'suppl_type':issue.suppl_type,
+            'suppl_type': issue.suppl_type,
             'suppl_text': issue.suppl_text,
             'publication_start_month': '2',
             'publication_end_month': '2',
@@ -3093,7 +3073,7 @@ class SpecialIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'spe_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'spe_type' : 'number',
+            'spe_type': 'number',
             'volume': '1',
             'number': '',
             'publication_start_month': '1',
@@ -3155,7 +3135,7 @@ class SpecialIssueFormClassTests(unittest.TestCase):
         POST = {
             'section': [section.pk],
             'spe_text': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod',
-            'spe_type' : 'number',
+            'spe_type': 'number',
             'volume': '',
             'number': '',
             'publication_start_month': '1',
@@ -3230,7 +3210,7 @@ class SpecialIssueFormClassTests(unittest.TestCase):
             'section': [section.pk],
             'volume': issue.volume,
             'number': issue.number,
-            'spe_type':'number',
+            'spe_type': 'number',
             'spe_text': issue.spe_text,
             'publication_start_month': '1',
             'publication_end_month': '2',
@@ -3408,12 +3388,12 @@ class SpecialIssueFormClassTests(unittest.TestCase):
         }
 
         issue_form = forms.SpecialIssueForm(POST,
-                                                instance=issue,
-                                                params={'journal': journal},
-                                                querysets={
-                                                    'section': journal.section_set.all(),
-                                                    'use_license': models.UseLicense.objects.all(),
-                                                })
+                                            instance=issue,
+                                            params={'journal': journal},
+                                            querysets={
+                                                'section': journal.section_set.all(),
+                                                'use_license': models.UseLicense.objects.all(),
+                                            })
 
         self.assertTrue(issue_form.is_valid())
 
@@ -3449,12 +3429,12 @@ class SpecialIssueFormClassTests(unittest.TestCase):
         }
 
         issue_form = forms.SpecialIssueForm(POST,
-                                                instance=issue,
-                                                params={'journal': journal},
-                                                querysets={
-                                                    'section': journal.section_set.all(),
-                                                    'use_license': models.UseLicense.objects.all(),
-                                                })
+                                            instance=issue,
+                                            params={'journal': journal},
+                                            querysets={
+                                                'section': journal.section_set.all(),
+                                                'use_license': models.UseLicense.objects.all(),
+                                            })
 
         self.assertTrue(issue_form.is_valid())
 
@@ -3479,24 +3459,22 @@ class IssueFormTests(WebTest):
         pass
 
     def _makeOneWithEditorialBoard(self):
-        #Create any issue in this journal
+        # Create any issue in this journal
         issue = modelfactories.IssueFactory(journal=self.journal)
 
-        #Create a board to the issue
+        # Create a board to the issue
         ed_board = EditorialBoardFactory(issue=issue)
 
-        #Add members to the board
+        # Add members to the board
         member = EditorialMemberFactory(board=ed_board)
         member = EditorialMemberFactory(board=ed_board)
 
         return issue
 
     def _makeOneWithoutEditorialBoard(self):
-        #Create any issue in this journal
+        # Create any issue in this journal
         issue = modelfactories.IssueFactory(journal=self.journal)
-
         return issue
-
 
     def test_basic_struture(self):
         """
@@ -3561,7 +3539,7 @@ class IssueFormTests(WebTest):
                 form['number'] = '3'
                 form['spe_type'] = 'number'
                 form['spe_text'] = 'X'
-            else: # regular
+            else:  # regular
                 form['number'] = '3'
                 form['volume'] = '29'
 
@@ -3578,55 +3556,6 @@ class IssueFormTests(WebTest):
 
             self.assertIn('Saved.', response.body)
             self.assertTemplateUsed(response, 'journalmanager/issue_list.html')
-
-    def test_POST_with_valid_formdata_without_editorialmanager_waffle(self):
-        """
-        TEST: #1021 - Corregir vazamento da funcionalidade de "Editorial Manager"
-        Submitting valid data in form, without 'editorialmanager' waffle, MUST NOT broke!
-        and process correctly the form. And NOT editorial members were created.
-        """
-        # create an issue with editorial board
-        issue = self._makeOneWithEditorialBoard()
-
-        perm_issue_change = _makePermission(perm='add_issue',
-            model='issue', app_label='journalmanager')
-        perm_issue_list = _makePermission(perm='list_issue',
-            model='issue', app_label='journalmanager')
-        self.user.user_permissions.add(perm_issue_change)
-        self.user.user_permissions.add(perm_issue_list)
-
-        for t in ['regular', 'supplement', 'special']:
-            form = self.app.get(reverse('issue.add_%s' % t, args=[self.journal.pk]), user=self.user).forms['issue-form']
-
-            if t == 'supplement':
-                form['number'] = ''
-                form['volume'] = '29'
-                form['suppl_type'] = 'volume'
-                form['suppl_text'] = 'suppl.X'
-            elif t == 'special':
-                form['number'] = '3'
-                form['spe_type'] = 'number'
-                form['spe_text'] = 'X'
-            else: # regular
-                form['number'] = '3'
-                form['volume'] = '29'
-
-            form['total_documents'] = '16'
-            form.set('ctrl_vocabulary', 'decs')
-
-            form['publication_start_month'] = '9'
-            form['publication_end_month'] = '11'
-            form['publication_year'] = '2012'
-            form['is_marked_up'] = False
-            form['editorial_standard'] = 'other'
-
-            response = form.submit().follow()
-
-            new_issue = models.Issue.objects.get(publication_year='2012', number='3', volume='29')
-            self.assertIn('Saved.', response.body)
-            self.assertTemplateUsed(response, 'journalmanager/issue_list.html')
-            # check: editorial board must not be created, because flag is not created
-            self.assertRaises(EditorialBoard.DoesNotExist, lambda: new_issue.editorialboard)
 
     def test_POST_with_valid_formdata_and_check_copy_of_editorial_board(self):
         """
@@ -3640,7 +3569,6 @@ class IssueFormTests(WebTest):
 
         This test check if editorial board of this issue was created
         """
-        Flag.objects.create(name='editorialmanager', everyone=True)
         # create an issue with editorial board
         issue = self._makeOneWithEditorialBoard()
 
@@ -3663,7 +3591,7 @@ class IssueFormTests(WebTest):
                 form['number'] = '3'
                 form['spe_type'] = 'number'
                 form['spe_text'] = 'X'
-            else: # regular
+            else:  # regular
                 form['number'] = '3'
                 form['volume'] = '29'
 
@@ -3680,11 +3608,11 @@ class IssueFormTests(WebTest):
 
             new_issue = models.Issue.objects.get(publication_year='2012', number='3', volume='29')
 
-            #Members of the recent IssueFormTests
+            # Members of the recent IssueFormTests
             new_members = new_issue.editorialboard.editorialmember_set.all()
             last_members = issue.editorialboard.editorialmember_set.all()
 
-            #comparing first names
+            # comparing first names
             last_first_names = [member.first_name for member in last_members]
             new_first_names = [member.first_name for member in new_members]
 
@@ -3707,7 +3635,7 @@ class IssueFormTests(WebTest):
         This test check if editorial board of this issue was created
         """
 
-        #create an issue
+        # create an issue
         issue = self._makeOneWithoutEditorialBoard()
 
         perm_issue_change = _makePermission(perm='add_issue',
@@ -3729,7 +3657,7 @@ class IssueFormTests(WebTest):
                 form['number'] = '3'
                 form['spe_type'] = 'number'
                 form['spe_text'] = 'X'
-            else: # regular
+            else:  # regular
                 form['number'] = '3'
                 form['volume'] = '29'
 
@@ -4025,7 +3953,7 @@ class IssueFormTests(WebTest):
                 form['number'] = '3'
                 form['spe_type'] = 'number'
                 form['spe_text'] = 'X'
-            else: # regular
+            else:  # regular
                 form['number'] = '3'
                 form['volume'] = '29'
 
@@ -4071,7 +3999,7 @@ class IssueFormTests(WebTest):
                 form['number'] = '3'
                 form['spe_type'] = 'number'
                 form['spe_text'] = 'X'
-            else: # regular
+            else:  # regular
                 form['number'] = '3'
                 form['volume'] = '29'
 

--- a/scielomanager/journalmanager/tests/tests_pages.py
+++ b/scielomanager/journalmanager/tests/tests_pages.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
 from django_factory_boy import auth
-from waffle import Flag
 
 from journalmanager.tests import modelfactories
 from journalmanager.tests.tests_forms import _makePermission
@@ -282,7 +281,6 @@ class IndexPageTests(WebTest):
         self.assertTemplateUsed(response, 'journalmanager/home_journal.html')
 
     def test_logged_editor_user_access_to_list_journal(self):
-        Flag.objects.create(name='editorialmanager', everyone=True)
         editors_group = modelfactories.GroupFactory.create(name='Editors')
         perm = _makePermission(perm='list_editor_journal', model='journal', app_label='journalmanager')
         editors_group.permissions.add(perm)

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -31,7 +31,6 @@ from django.forms.models import inlineformset_factory
 from django.forms.formsets import formset_factory
 from django.conf import settings
 from django.db.models import Q
-import waffle
 
 from . import models
 from .forms import *
@@ -752,7 +751,7 @@ def add_sponsor(request, sponsor_id=None):
     Handles new and existing sponsors
     """
 
-    if  sponsor_id is None:
+    if sponsor_id is None:
         sponsor = models.Sponsor()
     else:
         sponsor = get_object_or_404(models.Sponsor.userobjects.active(), id=sponsor_id)
@@ -833,14 +832,14 @@ def edit_issue(request, journal_id, issue_id=None):
             This method is useful to get the correct IssueForm based on issue_type.
         """
         form_kwargs = {
-            'params' : {
+            'params': {
                 'journal': journal,
             },
-            'querysets' : {
+            'querysets': {
                 'section': journal.section_set.filter(is_trashed=False),
                 'use_license': models.UseLicense.objects.all(),
             },
-            'instance' : instance,
+            'instance': instance,
         }
 
         form_args = []
@@ -968,7 +967,7 @@ def add_issue(request, issue_type, journal_id, issue_id=None):
                      'ctrl_vocabulary': journal.ctrl_vocabulary}
         issue = models.Issue()
 
-        #get last issue of the journal
+        # get last issue of the journal
         last_issue = journal.get_last_issue()
     else:
         data_dict = None
@@ -992,35 +991,34 @@ def add_issue(request, issue_type, journal_id, issue_id=None):
             if titleformset.is_valid():
                 titleformset.save()
 
-            if waffle.flag_is_active(request, 'editorialmanager'):
-                # if is a new issue copy editorial board from the last issue
-                if issue_id is None and last_issue:
-                    try:
-                        members = last_issue.editorialboard.editorialmember_set.all()
-                    except ObjectDoesNotExist:
-                        messages.info(request,
-                            _("Issue created successfully, however we can not create the editorial board."))
-                        notifications.issue_board_replica(issue, 'issue_add_no_replicated_board')
-                    else:
-                        ed_board = EditorialBoard()
-                        ed_board.issue = saved_issue
-                        ed_board.save()
+            # if is a new issue copy editorial board from the last issue
+            if issue_id is None and last_issue:
+                try:
+                    members = last_issue.editorialboard.editorialmember_set.all()
+                except ObjectDoesNotExist:
+                    messages.info(request,
+                        _("Issue created successfully, however we can not create the editorial board."))
+                    notifications.issue_board_replica(issue, 'issue_add_no_replicated_board')
+                else:
+                    ed_board = EditorialBoard()
+                    ed_board.issue = saved_issue
+                    ed_board.save()
 
-                        for member in members:
-                            member.board = ed_board
-                            member.pk = None
-                            member.save()
+                    for member in members:
+                        member.board = ed_board
+                        member.pk = None
+                        member.save()
 
-                        notifications.issue_board_replica(issue, 'issue_add_replicated_board')
+                    notifications.issue_board_replica(issue, 'issue_add_replicated_board')
 
-                audit_data = {
-                    'user': request.user,
-                    'obj': issue,
-                    'message': helpers.construct_create_message(add_form, [titleformset, ]),
-                    'old_values': '',
-                    'new_values': helpers.collect_new_values(add_form, [titleformset, ]),
-                }
-                helpers.log_create(**audit_data)
+            audit_data = {
+                'user': request.user,
+                'obj': issue,
+                'message': helpers.construct_create_message(add_form, [titleformset, ]),
+                'old_values': '',
+                'new_values': helpers.collect_new_values(add_form, [titleformset, ]),
+            }
+            helpers.log_create(**audit_data)
 
             messages.info(request, MSG_FORM_SAVED)
 
@@ -1276,7 +1274,7 @@ def ajx_add_journal_to_user_collection(request, journal_id):
         }
 
     else:
-        #The journal is join to new collection with status ``inprogress``
+        # The journal is join to new collection with status ``inprogress``
         journal.join(user_collection, request.user)
         messages.error(request, _('%s add to collection %s') % (journal, user_collection))
 

--- a/scielomanager/scielomanager/templates/base_lv1.html
+++ b/scielomanager/scielomanager/templates/base_lv1.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 {% load user_collections_dashboard %}
-{% load waffle_tags %}
 {% load menu_active %}
 {% load user_avatar %}
 

--- a/scielomanager/scielomanager/templates/base_lv1.html
+++ b/scielomanager/scielomanager/templates/base_lv1.html
@@ -21,14 +21,12 @@
       <div id="global-nav" class="nav-collapse collapse">
         <ul id="site-areas" class="nav">
 
-          {# Only users with list_editor_journal see this nemu option. #}
-          {% flag 'editorialmanager' %}
-            {% if request.user.get_profile.is_editor %}
-              <li id="users-link" class="active">
-                <a href="{% url editorial.index %}">{% trans 'My Journals' %}</a>
-              </li>
-            {% endif %}
-          {% endflag %}
+          {# Only users with list_editor_journal see this menu option. #}
+          {% if request.user.get_profile.is_editor %}
+            <li id="users-link" class="active">
+              <a href="{% url editorial.index %}">{% trans 'My Journals' %}</a>
+            </li>
+          {% endif %}
 
           {% if perms.journalmanager.list_journal %}
             <li id="journals-link" class="{% active '/journal/$' %}">

--- a/scielomanager/scielomanager/templates/footer.html
+++ b/scielomanager/scielomanager/templates/footer.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load waffle_tags %}
 
 <div class="footer row-fluid">
   <div class="span3">

--- a/scielomanager/scielomanager/urls.py
+++ b/scielomanager/scielomanager/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls.defaults import *
 from django.contrib import admin
 from django.conf import settings
 from tastypie.api import Api
-import waffle
 
 from journalmanager import views, models
 from api import resources_v1, resources_v2

--- a/scielomanager/validator/tests/tests_pages.py
+++ b/scielomanager/validator/tests/tests_pages.py
@@ -54,9 +54,6 @@ def get_temporary_xml_file(xml_abs_path):
 
 class ValidatorTests(WebTest, mocker.MockerTestCase):
 
-    def _addWaffleFlag(self):
-        Flag.objects.create(name='packtools_validator', everyone=True)
-
     def test_access_unauthenticated_user(self):
         response = self.app.get(
             reverse('validator.packtools.stylechecker',),


### PR DESCRIPTION
#### objetivo do PR?
remover o waffle de controle: 'editorialmanager' em todo o projeto.

#### tickets relacionados?
- FIX: #1132
- #1091 

#### comentarios:
foi feitos alguns ajustes menores de PEP 8
