### PR TITLE
Explicitando o mimetype na view para adicionar um novo membro no corpo editorial

### DIFF
--- a/scielomanager/editorialmanager/views.py
+++ b/scielomanager/editorialmanager/views.py
@@ -394,7 +394,8 @@ def add_board_member(request, journal_id, issue_id):
         else:
             messages.error(request, _('Check mandatory fields.'))
             context['form'] = form
-            return render_to_response(template_name, context, context_instance=RequestContext(request))
+            return render_to_response(template_name, context,
+                mimetype="text/plain", context_instance=RequestContext(request))
     else:
         form = forms.EditorialMemberForm()
 


### PR DESCRIPTION
Ref. #1137 

Esse bug tem uma solução simples, porém extremamente complexo de ser identificado, pois é um comportamento indesejável que acontece em alguma camada ainda não explicada em sua exatidão.

Utilizamos modal em algumas áreas do SciELO Manager, esse componente utiliza AJAX para o preenchimento do seu conteúdo :-). No ambiente de desenvolvimento o preenchimento desse conteúdo ocorre em sua totalidade e sem qualquer impacto, porém validando o ambiente de homologação verifiquei que existia uma intermitência no comportamento do componente... :-(.

Entre idas e vindas.... consegui constatar que o AJAX da view do Django retornada não é a mesma... ela recebe outras tags.... e essas tags deixam o javascript desorientado resultando em um comportamento estranho do componente.

Ainda não estou convencido que essa é a solução correta e precisamos pesquisar mais a fundo para saber em que camada esta o "gato", esse tipo de manipulação de conteúdo é bastante preocupante uma vez que perdermos o controle do conteúdo trafegado entre o servidor e o cliente. 

Para solucionar de forma que possamos utilizar os recursos atuais e possamos continuar desenvolvendo  novos recurso, decidimos retorna o conteúdo com **texto**, parece que desviamos do "gato", rsrsrs.

Mais sobre: http://www.daybarr.com/blog/ajax_content_type 




  