### PR TITLE
fix para disparar eventos após a carga de conteúdo "remoto" nos modals

### DIFF
--- a/scielomanager/scielomanager/static/js/modal.js
+++ b/scielomanager/scielomanager/static/js/modal.js
@@ -1,8 +1,36 @@
+// include onetime, somewhere
+// this patch trigger a new event "loaded" when jquery.load function receive the ajax response
+// more context about the fix: https://github.com/twbs/bootstrap/pull/6846
+
+(function(){
+    $.fn.jqueryLoad = $.fn.load;
+
+    $.fn.load = function(url, params, callback) {
+        var $this = $(this);
+        var cb = $.isFunction(params) ? params: callback || $.noop;
+        var wrapped = function(responseText, textStatus, XMLHttpRequest) {
+            cb(responseText, textStatus, XMLHttpRequest);
+            $this.trigger('loaded');
+        };
+
+        if ($.isFunction(params)) {
+            params = wrapped;
+        } else {
+            callback = wrapped;
+        }
+
+        $this.jqueryLoad(url, params, callback);
+
+        return this;
+    };
+})();
+
+
 $(function() {
 
   /* hack to reload ajax content, and avoid caching trap */
   $('.modal').on('hidden', function() { $(this).removeData(); })
-  $('.modal').on('shown', function () {
+  $('.modal').on('loaded', function () {
     $(this).find('input').addClass('span12');
     $(this).find(".chzn-select").chosen({
       no_results_text: "{% trans 'No results found for' %}:",


### PR DESCRIPTION
#### objetivo do PR:
resolver o glitch quando é aberto um modal que contém um form

#### test manual?:
- na página do board, no editorial manager: abrir um modal clickando em: **add new member**
- na página do board, no editorial manager: abrir um modal clickando em: **edit** (botão azul) do lado de algum Board Member cadastrado.
