### PR TITLE
Alterando param no CountryField() para que tenhamos um valor vazio no componente da interface.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-kombu
 defusedxml==0.4.1
 cython
 thriftpy
-django-countries
+django-countries==3.3
 -e git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap
 elasticsearch>=1.0.0,<2.0.0
-zerorpc>=0.4.4   
+zerorpc>=0.4.4

--- a/scielomanager/editorialmanager/models.py
+++ b/scielomanager/editorialmanager/models.py
@@ -35,7 +35,7 @@ class EditorialMember(models.Model):
     link_cv = models.URLField(_('Link CV'), null=True, blank=True)
     city = models.CharField(_('City'), max_length=256, null=True, blank=True)
     state = models.CharField(_('State'), max_length=256, null=True, blank=True)
-    country = CountryField(_('Country'), default='')
+    country = CountryField(_('Country'), blank_label="----------")
     research_id = models.CharField(_('ResearchID'), max_length=256, null=True, blank=True)
     orcid = models.CharField(_('ORCID'), max_length=256, null=True, blank=True)
 


### PR DESCRIPTION
Ref #1153. 

Para que essa atividade é necessário atualizar o django-countries==3.0.1(atual) para django-countries==3.3. 

