### PR TITLE
Funções de recuperação de registros na interface RPC Thrift.

### DIFF
--- a/docs/dev/rpc_spec/getScanArticlesBatch.rst
+++ b/docs/dev/rpc_spec/getScanArticlesBatch.rst
@@ -1,0 +1,33 @@
+.. _func-getScanArticlesBatch:
+
+``scanResults getScanArticlesBatch(1:string batch_id) throws (1:ServerError srv_err, 2:BadRequestError req_err, 3:TimeoutError tou_err);``
+==========================================================================================================================================
+
+
+Retorna a struct ``ScanArticlesResults`` representando o lote identificado 
+por *batch_id*. A struct contém dois campos: 1) next_batch_id - que é o 
+identificador para a obtenção do próximo lote e 2) articles - a lista de 
+``Article``. 
+
+A responsabilidade de saber o momento de parar de solicitar por novos lotes é 
+do cliente. O serviço sempre retornará valores para ''next_batch_id'', mesmo 
+que não haja mais resultado.
+
+
+Exemplo:: 
+
+    def get_articles(year):
+        batch_id = client.scanArticles(
+                '{"query": {"match": {"year": %s}}, "size": 50}' % year)
+
+        while True:
+            result = client.getScanArticlesBatch(batch_id)
+
+            if not result.articles:
+                return
+
+            for article in result.articles:
+                yield article
+
+            batch_id = result.next_batch_id
+

--- a/docs/dev/rpc_spec/scanArticles.rst
+++ b/docs/dev/rpc_spec/scanArticles.rst
@@ -1,0 +1,58 @@
+.. _func-scanArticles:
+
+``string scanArticles(1:string es_dsl_query) throws (1:ServerError srv_err, 2:BadRequestError req_err, 3:TimeoutError tou_err);``
+=================================================================================================================================
+
+
+Realiza consulta nos registros do tipo de ``journalmanager.models.Article``, 
+fazendo uso da DSL do Elasticsearch, e retorna identificador para o primeiro 
+lote de resultados.
+
+Os índices que podem ser utilizados na consulta são:
+
++----------------------+------------------------------------------------------+
+| Índice               | Descrição                                            |
++======================+======================================================+
+| abbrev_journal_title | Título abreviado do periódico conforme ISSN.         |
++----------------------+------------------------------------------------------+
+| epub                 | ISSN eletrônico do periódico.                        |
++----------------------+------------------------------------------------------+
+| ppub                 | ISSN impresso do periódico.                          |
++----------------------+------------------------------------------------------+
+| volume               | Identificador de volume do fascículo o qual o artigo | 
+|                      | é parte.                                             |
++----------------------+------------------------------------------------------+
+| issue                | Identificador do fascículo o qual o artigo é parte.  |
++----------------------+------------------------------------------------------+
+| year                 | Ano de publicação.                                   |
++----------------------+------------------------------------------------------+
+| doi                  | Digital Object Identifier.                           |
++----------------------+------------------------------------------------------+
+| pid                  | Identificador único de artigo (legado).              |
++----------------------+------------------------------------------------------+
+| aid                  | Article Id (identificador único atual).              |
++----------------------+------------------------------------------------------+
+| head_subject         | Seção do fascículo a qual o artigo é parte.          |
++----------------------+------------------------------------------------------+
+| article_type         | O tipo do documento conforme consta no doc XML.      |                     
++----------------------+------------------------------------------------------+
+| version              | A versão da especificação SciELO PS.                 |
++----------------------+------------------------------------------------------+
+| is_aop               | Se o artigo é `ahead of print`.                      |
++----------------------+------------------------------------------------------+
+| source               | O documento XML codificado em utf-8.                 |
++----------------------+------------------------------------------------------+
+
+
+.. note:: A quantidade de registros por lote não é definida pelo cliente, e 
+          sim pelo servidor, a fim de manter a saúde dos serviços.
+
+
+Exemplo::
+
+    batch_id = client.scanArticles('{"query": {"match": {"year": "2013"}}}')
+    next_batch_id, articles = client.getScanArticlesBatch(batch_id)
+
+    for article in articles:
+        ...
+

--- a/scielomanager/scielomanager/connectors/__init__.py
+++ b/scielomanager/scielomanager/connectors/__init__.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""Pacote `scielomanager.connectors`.
+
+Um conector é apenas um link entre dois ou mais elementos conectáveis (e.g.,
+portas, interfaces etc).
+"""
+
+# se apoia na definição da variável __all__ nos módulos.
+from .storage import *
+
+
+__all__ = (storage.__all__,)
+

--- a/scielomanager/scielomanager/connectors/exceptions.py
+++ b/scielomanager/scielomanager/connectors/exceptions.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+"""Exceções do pacote `connectors`.
+
+O dicionário `translations` contém traduções de códigos de erro HTTP,
+utilizados pela interface Restful do Elasticsearch, para as definidas
+localmente.
+"""
+
+
+class BaseConnectorError(Exception):
+    """Base para exceções do pacote `connectors`.
+    """
+
+
+class BadRequestError(BaseConnectorError):
+    """Erro no conjunto de argumentos enviado ao servidor.
+    """
+
+
+class NotFoundError(BaseConnectorError):
+    """O registro solicitado não existe.
+    """
+
+
+class TimeoutError(BaseConnectorError):
+    """Tempo de conexão excedido.
+    """
+
+
+class ServerError(BaseConnectorError):
+    """Algo ruim aconteceu no servidor.
+    """
+
+
+translations = {
+        400: BadRequestError,
+        404: NotFoundError,
+        408: TimeoutError,
+        500: ServerError,
+        501: ServerError,
+        502: ServerError,
+        503: ServerError,
+        504: ServerError,
+        506: ServerError,
+}
+

--- a/scielomanager/scielomanager/connectors/storage.py
+++ b/scielomanager/scielomanager/connectors/storage.py
@@ -1,0 +1,128 @@
+# coding: utf-8
+"""
+Interface do connector tipo `Storage`:
+    - add(id: str, data: dict)
+    - get(id: str) -> dict
+    - scan(query: str) -> str
+    - scroll(scroll_id: str) -> (str, list)
+"""
+import logging
+import functools
+
+import elasticsearch
+
+from .. import tools
+from . import exceptions
+
+
+__all__ = ['ArticleElasticsearch']
+
+
+LOGGER = logging.getLogger(__name__)
+# Consumo de memória com XML (aprox): ES_RESULTS_PER_SHARD * total_shards * 200KB
+# i.e., 10MB por lote (atualmente com 5 shards).
+ES_RESULTS_PER_SHARD = '10'
+ES_SCROLL_TIMEOUT = '30s'
+ES_NODES = tools.get_setting_or_raise('ELASTICSEARCH_NODES')
+ES_ARTICLE_INDEX_NAME = tools.get_setting_or_raise('ES_ARTICLE_INDEX_NAME')
+ES_ARTICLE_DOC_TYPE = tools.get_setting_or_raise('ES_ARTICLE_DOC_TYPE')
+
+
+def translate_exceptions(wrapped):
+    """Traduz exceções das dependências internas do pacote, para as que
+    fazem parte da sua API.
+    """
+    @functools.wraps(wrapped)
+    def _wrapper(*args, **kwargs):
+        try:
+            return wrapped(*args, **kwargs)
+        except elasticsearch.exceptions.TransportError as exc:
+            # Caso não haja exceção mapeada para esse caso, será levantada a
+            # exceção mais genérica: BaseConnectorError.
+            new_exception = exceptions.translations.get(
+                    exc.status_code, exceptions.BaseConnectorError)
+            raise new_exception(exc.message)
+
+    return _wrapper
+
+
+def ArticleElasticsearch():
+    """Fábrica de connectores do Elasticsearch para entidades `article`.
+
+    O cliente é pré-configurado de acordo com as diretivas definidas na
+    configuração do projeto.
+
+    As diretivas são:
+      - ELASTICSEARCH_NODES
+      - ES_ARTICLE_INDEX_NAME
+      - ES_ARTICLE_DOC_TYPE
+    """
+    if not hasattr(ArticleElasticsearch, '_cached_client'):
+        ArticleElasticsearch._cached_client = elasticsearch.Elasticsearch(ES_NODES)
+
+    return _Elasticsearch(ArticleElasticsearch._cached_client,
+            ES_ARTICLE_INDEX_NAME, ES_ARTICLE_DOC_TYPE)
+
+
+class _Elasticsearch(object):
+    """Adapta a interface de `elasticsearch.Elasticsearch`.
+    """
+    def __init__(self, es_client, index, doctype):
+        self.es_client = es_client
+        self.index = index
+        self.doctype = doctype
+
+    def __repr__(self):
+        return u'<%s es_client=%s index=%s doctype=%s>' % (
+                self.__class__.__name__, self.es_client, self.index,
+                self.doctype)
+
+    @translate_exceptions
+    def add(self, id, data):
+        """Armazena `data` sob o identificador `id`.
+
+        Registros serão sobrescritos caso `id` corresponda a um registro já
+        armazenado.
+        """
+        _ = self.es_client.index(index=self.index, doc_type=self.doctype,
+                id=id, body=data)
+
+    def get(self, id):
+        return NotImplemented
+
+    @translate_exceptions
+    def scan(self, query):
+        """Consulta expressão definida por `query`.
+
+        Esse método é otimizado para a recuperação de grandes quantidades de
+        dados, portanto: 1) a ordenação dos resultados por relevância é
+        desabilitada e 2) os resultados devem ser recuperados por lotes.
+        """
+        resp = self.es_client.search(body=query, scroll=ES_SCROLL_TIMEOUT,
+                search_type='scan', index=self.index, doc_type=self.doctype,
+                size=ES_RESULTS_PER_SHARD)
+
+        return resp.get('_scroll_id')
+
+    @translate_exceptions
+    def scroll(self, scroll_id):
+        """Recupera lote identificado por `scroll_id`.
+
+        Retorna um tupla contendo o `scroll_id` do próximo lote e a lista de
+        resultados. Lotes podem conter zero resultado, e a decisão de parar
+        de pedir por novos lotes deve ser do consumidor.
+        """
+        resp = self.es_client.scroll(scroll_id, scroll=ES_SCROLL_TIMEOUT)
+
+        results = []
+        for result in resp.get('hits', {}).get('hits', []):
+            try:
+                source = result['_source']
+            except KeyError:
+                LOGGER.warning('Cannot find field "_source" in record "%s"',
+                        result['_id'])
+            else:
+                results.append(source)
+
+        return resp.get('_scroll_id'), results
+

--- a/scielomanager/scielomanager/settings.py
+++ b/scielomanager/scielomanager/settings.py
@@ -312,7 +312,7 @@ IPC_HEALTHD_BIND_ADDR = 'tcp://0.0.0.0:11711'
 
 
 ELASTICSEARCH_NODES = (
-    'localhost:9200',
+    'localhost:0',
     # 'esa.scielo.org:9200',
     # 'esb.scielo.org:9200',
     # 'esc.scielo.org:9200',

--- a/scielomanager/scielomanager/tests/tests_connectors.py
+++ b/scielomanager/scielomanager/tests/tests_connectors.py
@@ -1,0 +1,12 @@
+# coding:utf-8
+from mocker import MockerTestCase
+
+from scielomanager.connectors.storage import ArticleElasticsearch
+
+
+class ElasticsearchTests(MockerTestCase):
+
+    def test_client_is_reused(self):
+        self.assertEqual(ArticleElasticsearch().es_client,
+                         ArticleElasticsearch().es_client)
+

--- a/scielomanager/scielomanager/tools.py
+++ b/scielomanager/scielomanager/tools.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 try:
     from hashlib import md5
-except:
+except ImportError:
     from md5 import new as md5
 import re
 
@@ -9,8 +9,9 @@ from django.db.models.sql.datastructures import EmptyResultSet
 from django.core.paginator import EmptyPage
 from django.core.paginator import Paginator
 from django.contrib.auth.models import Group, User
+from django.core import exceptions
 
-from scielomanager import settings
+from django.conf import settings
 
 
 class NullPaginator(object):
@@ -136,3 +137,14 @@ def user_receive_emails(user):
         return user.get_profile().email_notifications
     else:
         return False
+
+
+def get_setting_or_raise(name):
+    """ Retorna a diretiva de configuração `name` ou levanta exceção.
+    """
+    try:
+        setting = getattr(settings, name)
+    except AttributeError:
+        raise exceptions.ImproperlyConfigured('Setting "%s" is missing' % name)
+
+    return setting

--- a/scielomanager/thrift/scielomanager.thrift
+++ b/scielomanager/thrift/scielomanager.thrift
@@ -1,15 +1,97 @@
+#!/usr/local/bin/thrift --py
+# Copyright (c) 2012, SciELO <scielo-dev@googlegroups.com>
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+#     Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+# 
+#     Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+
+namespace java org.scielo.scielomanager.thrift
+namespace py scielomanager
+
+
 /*
- * Exceções.
- *
- * ServerError é levantada sempre que um erro inesperado ocorre no servidor. 
- * Equivale aos erros da classe 5xx do protocolo HTTP.
+ * IMPORTANTE! Alterar o valor de VERSION após qualquer alteração na interface.
+ * Regras em: http://semver.org/lang/pt-BR/
  */
+const string VERSION = "1.0.0"
+
+
+#
+# Exceções
+#
+
+/* Levantada sempre que um erro inesperado ocorre no servidor. */
 exception ServerError {
-    1: string message;
+}
+
+/* Ocorre quando há algum problema com o valor passado como argumento. */
+exception BadRequestError {
+    1: optional string message;
+}
+
+/* A operação foi abortada pois o tempo excedeu na comunicação com o backend. */
+exception TimeoutError {
+}
+
+
+/*
+ * Article representa um documento XML em conformidade com a especificação 
+ * SciELO-PS, em qualquer uma das versões, ou pré-sps para os documentos 
+ * mais antigos.
+ */
+struct Article {
+    1: optional string abbrev_journal_title;
+    2: optional string epub;
+    3: optional string ppub;
+    4: optional string volume;
+    5: optional string issue;
+    6: optional string year;
+    7: optional string doi;
+    8: optional string pid;
+    9: required string aid;
+    10: optional string head_subject;
+    11: required string article_type;
+    12: required string version;
+    13: optional bool is_aop;
+    14: required string source;
 }
 
 /*
- * Manuseio de requisições assíncronas.
+ * ScanArticlesResults representa um lote de entidades Article, retornado 
+ * após uma consulta por meio da função ScanArticles.
+ */
+struct ScanArticlesResults {
+    1: optional list<Article> articles;
+    2: optional string next_batch_id;
+}
+
+/*
+ * ResultStatus representa o status da execução de uma tarefa assíncrona.
+ *
+ * Os valores possíveis são:
+ *  - PENDING: A tarefa ainda não foi executada.
+ *  - STARTED: A tarefa está em execução.
+ *  - RETRY: A execução da tarefa falhou, e uma nova tentativa está agendada.
+ *  - FAILURE: A execução da tarefa falhou definitivamente.
+ *  - SUCCESS: A tarefa foi executada com sucesso.
  */
 enum ResultStatus {
     PENDING,
@@ -19,17 +101,18 @@ enum ResultStatus {
     SUCCESS
 }
 
+/*
+ * AsyncResult representa o resultado da execução de uma tarefa assíncrona.
+ */
 struct AsyncResult {
     1: ResultStatus status;
     2: string value;                  // string codificada em json
 }
 
-/*
- * Protótipo dos serviços.
- */
+
 service JournalManagerServices {
     /*
-     * Funções assíncronas. 
+     * Adiciona uma nova entidade tipo Article, com base no seu doc XML.
      *
      * Retorna string `task_id` correspondente ao identificador da tarefa
      * criada. `task_id` deve ser utilizada para obter o resultado da função. 
@@ -37,9 +120,31 @@ service JournalManagerServices {
     string addArticle(1:string xml_string) throws (1:ServerError srv_err);
 
     /*
-     * Funções síncronas - seja bacana e utilize suas versões assíncronas 
-     * quando disponíveis.
+     * Consulta o resultado da execução de uma determinada tarefa assíncrona.
      */
     AsyncResult getTaskResult(1:string task_id) throws (1:ServerError srv_err); 
+
+    /*
+     * Realiza consulta em entidades do tipo `Article`.
+     *
+     * A consulta deve ser expressa utilizando a sintaxe `Query DSL` do 
+     * Elasticsearch (http://bit.ly/1I9g37B). Os resultados não são ordenados
+     * por relevância.
+     *
+     * Retorna string `batch_id` correspondente ao primeiro lote de resultados
+     * que devem ser recuperados utilizando a função `getScanArticlesBatch`.
+     */
+    string scanArticles(1:string es_dsl_query) throws (1:ServerError srv_err, 
+            2:BadRequestError req_err, 3:TimeoutError tou_err); 
+
+    /*
+     * Obtém lote de resultados de consulta.
+     *
+     * Os resultados são representados por structs `ScanArticlesResults`. O 
+     * campo `next_batch_id` apresenta o identificador do próximo lote.
+     */
+    ScanArticlesResults getScanArticlesBatch(1:string batch_id) throws (
+            1:ServerError srv_err, 2:BadRequestError req_err, 
+            3:TimeoutError tou_err); 
 }
 


### PR DESCRIPTION
Definidas as funções *scanArticles* e *getScanArticlesBatch*, conforme
as especificações:

  - scanArticles: docs/dev/rpc_spec/scanArticles.rst
  - getScanArticlesBatch: docs/dev/rpc_spec/getScanArticlesBatch.rst

A implementação das funções envolve consultas ao Elasticsearch, o que
provocou uma reorganização dos códigos de conexão que foram movidos para
o pacote `scielomanager.connectors`. A proposta é que esse pacote agrupe
classes que representem o link entre o projeto e componentes externos -
no caso o projeto e o Elasticsearch. Além disso também foi definido o
adaptador `scielomanager.connectors._Elasticsearch`, implementando uma
interface de mais alto-nível em relação à lib `elasticsearch-py`.

Ainda sobre Elasticsearch, também foi realizada uma alteração do schema de
documentos do tipo ``article``, onde foi removido o campo ``b64_source``
e foi acrescentado o campo ``aid``.

Os testes de unidade ainda estão pendentes de implementação. Ainda estou
avaliando uma maneira boa de testar a integração com o ES.