### PR TITLE
Remover app waffles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ webassets==0.7.1
 yuicompressor
 jsonfield
 django-tastypie==0.9.16
-django-waffle==0.9.1
 -e git+git://github.com/scieloorg/django-htmlmin.git#egg=django-htmlmin
 -e git+git://github.com/scieloorg/django-cache-machine.git#egg=django-cache-machine
 packtools

--- a/scielomanager/remove_tables_waffle_app.sql
+++ b/scielomanager/remove_tables_waffle_app.sql
@@ -1,0 +1,9 @@
+BEGIN;
+DROP TABLE IF EXISTS "waffle_sample" CASCADE;
+DROP TABLE IF EXISTS  "waffle_switch" CASCADE;
+ALTER TABLE IF EXISTS "waffle_flag_users" DROP CONSTRAINT IF EXISTS "flag_id_refs_id_8fef0c12" CASCADE;
+ALTER TABLE IF EXISTS "waffle_flag_groups" DROP CONSTRAINT IF EXISTS "flag_id_refs_id_8e6a807d" CASCADE;
+DROP TABLE IF EXISTS "waffle_flag" CASCADE;
+DROP TABLE IF EXISTS "waffle_flag_users" CASCADE;
+DROP TABLE IF EXISTS "waffle_flag_groups" CASCADE;
+COMMIT;

--- a/scielomanager/scielomanager/settings.py
+++ b/scielomanager/scielomanager/settings.py
@@ -131,7 +131,6 @@ MIDDLEWARE_CLASSES = (
     'scielomanager.utils.middlewares.threadlocal.ThreadLocalMiddleware',
     'maintenancewindow.middleware.MaintenanceMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'waffle.middleware.WaffleMiddleware',
     'django.middleware.transaction.TransactionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
 )
@@ -161,7 +160,6 @@ INSTALLED_APPS = (
     'widget_tweaks',
     'djcelery',
     'tastypie',
-    'waffle',
     'south',
 
     # SciELO shared apps


### PR DESCRIPTION
FIXES: #1091

##### Pasos para realizar manualmente no servidor:

0. fazer backup do DB!!
1. atualizar o codigo ``git pull ...``
2. make test
3. remover o pacote do ambiente/sistema: ``pip uninstall django-waffle``
4. aplicar snippet SQL para eliminar tabelas do banco: ``cat remove_tables_waffle_app.sql | psql MANAGER_DB_NAME  -U MANAGER_DB_USER``
5. make test
6. :beers: cheers! :beers: