### PR TITLE
Microafinação na chave de domínio das entidades `Article`.

### DIFF
--- a/scielomanager/journalmanager/tests/xml_samples/0034-8910-rsp-48-2-0216.xml
+++ b/scielomanager/journalmanager/tests/xml_samples/0034-8910-rsp-48-2-0216.xml
@@ -86,7 +86,7 @@
 			</pub-date>
 			<volume>48</volume>
 			<issue>2</issue>
-			<fpage>216</fpage>
+			<fpage seq="a">216</fpage>
 			<lpage>224</lpage>
 			<history>
 				<date date-type="received">


### PR DESCRIPTION
A chave de domínio passou a integrar os valores de fpage/@seq e
article-id[@pub-id-type="other"] a fim de desambiguar documentos que
compatilham numeração de página e artigos AOP. Essa alteração corrige um
bug que considerava artigos AOP do mesmo ano como duplicados.

Além disso, também foi alterada a lógica de inferência de artigos AOP
pelo SciELO Manager. A explicação que segue está descrita na docstring
do método `journalmanager.models.Article._get_is_aop`:

    Diferentemente das regras publicadas no SciELO PS, o SciELO
    Manager considera AOP (ahead-of-print) os artigos que
    apresentam o número identificador de AOP no elemento
    ``//article-meta/article-id[pub-id-type="other"]``.
    O SciELO Manager adota uma abordagem não-opinionada acerca da
    estrutura de publicação do periódico, portanto não utiliza
    metadados do número na lógica de inferência.

Para que esses códigos façam efeito, **TODAS** as instâncias de *journalmanager.Article* devem ser salvas novamente com o método *save_dirty()*. 