### PR TITLE
Configuração padrão de logs

### DIFF
--- a/scielomanager/scielomanager/settings.py
+++ b/scielomanager/scielomanager/settings.py
@@ -206,28 +206,58 @@ MESSAGE_TAGS = {
 
 FIXTURE_DIRS = (os.path.join(HERE, 'fixtures'),)
 
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
+# Reconfiguração total do sistema de logs do projeto.
+# http://stackoverflow.com/a/22336174
+LOGGING_CONFIG = None
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': False,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'simple': {
+            'format': '%(asctime)s %(name)s[%(process)d] [%(levelname)s] %(message)s',
+        },
+    },
     'handlers': {
+        'console': {
+            'level': 'NOTSET',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
+        '': {
+            'handlers': ['console'],
             'level': 'ERROR',
-            'propagate': True,
+        },
+        'django.request': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'thrift': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'health': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'packtools': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
+            'propagate': False,
         },
     }
 }
+import logging.config
+logging.config.dictConfig(LOGGING)
+
 
 AUTH_PROFILE_MODULE = 'journalmanager.UserProfile'
 


### PR DESCRIPTION
Os logs foram configurados de maneira que *loggers* não definidos sejam propagados e tratados pelo *root logger*. 

O comportamento definido foi:
* 2 handlers: 1) console -> logging.StreamHandle, que não define o nível de log e 2) mail_admins -> django.utils.log.AdminEmailHandler, que trata apenas logs de nível ERROR.
* 5 loggers: 1) raíz, que captura todos os erros de nível ERROR do projeto e suas dependências, 2) django.request, que envia email para os admins com traceback em erros em request/response, 3)4)5) que capturam mensagens de nível INFO para serviços da app e o packtools.

Também defini um formato para a mensagem de log que penso ser bom: ``'%(asctime)s %(name)s[%(process)d] [%(levelname)s] %(message)s'``
 