### PR TITLE
#1188 - revisão dos logs gerado na execução de tests

### DIFF
--- a/scielomanager/editorialmanager/tests/tests_notifications.py
+++ b/scielomanager/editorialmanager/tests/tests_notifications.py
@@ -12,7 +12,7 @@ from . import modelfactories as editorial_modelfactories
 
 
 class IssueBoardMessageTests(TestCase):
-    ACTIONS =  [
+    ACTIONS = [
         'issue_add_no_replicated_board',
         'issue_add_replicated_board',
     ]
@@ -77,7 +77,7 @@ class IssueBoardMessageTests(TestCase):
 
 
 class BoardMembersMessageTests(TestCase):
-    ACTIONS =  [
+    ACTIONS = [
         'board_add_member',
         'board_edit_member',
         'board_delete_member',

--- a/scielomanager/scielomanager/settings_tests.py
+++ b/scielomanager/scielomanager/settings_tests.py
@@ -26,11 +26,19 @@ API_BALAIO_DEFAULT_TIMEOUT = 0  # in seconds
 JOURNAL_COVER_MAX_SIZE = 30 * 1024
 JOURNAL_LOGO_MAX_SIZE = 13 * 1024
 
-#Use this command to start a little SMTP server
-#python -m smtpd -n -c DebuggingServer localhost:1025
+# Use this command to start a little SMTP server
+# python -m smtpd -n -c DebuggingServer localhost:1025
 
 EMAIL_HOST = 'localhost'
 EMAIL_USE_TLS = False
 EMAIL_PORT = 1025
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
+
+# Deshabilitar logging na execução dos test para um determinado nível.
+# Issue relacionado: https://github.com/scieloorg/scielo-manager/issues/1188
+# Valores aceitaveis:
+# - False: não deshabilita o logging.
+# - 'CRITICAL' ou 'DEBUG' ou 'ERROR', etc. : dehabilita loggings abaixo do nivel especificado.
+
+DISABLE_LOGGING_BELOW_LEVEL = 'CRITICAL'  # set to False to enable loggings

--- a/scielomanager/scielomanager/utils/runner.py
+++ b/scielomanager/scielomanager/utils/runner.py
@@ -16,14 +16,30 @@ This code doesn't modify the default unittest2 test discovery behavior, which
 only searches for tests in files named "test*.py".
 
 """
+import logging
+import warnings
 from django.conf import settings
 from django.test import TestCase
 from django.test.simple import DjangoTestSuiteRunner, reorder_suite
 from django.utils.importlib import import_module
 from django.utils.unittest.loader import defaultTestLoader
+from scielomanager.tools import get_setting_or_raise
+
+
+DISABLE_LOGGING_BELOW_LEVEL = get_setting_or_raise('DISABLE_LOGGING_BELOW_LEVEL')
 
 
 class DiscoveryRunner(DjangoTestSuiteRunner):
+
+    def setup_test_environment(self, **kwargs):
+        if DISABLE_LOGGING_BELOW_LEVEL:
+            level = getattr(logging, DISABLE_LOGGING_BELOW_LEVEL)
+            logging.disable(level)
+            warnings.warn(
+                "Loggings has beed disabled below level: %s" % DISABLE_LOGGING_BELOW_LEVEL
+            )
+        return super(DiscoveryRunner, self).setup_test_environment(**kwargs)
+
     """A test suite runner that uses unittest2 test discovery."""
     def build_suite(self, test_labels, extra_tests=None, **kwargs):
         suite = None


### PR DESCRIPTION
nova setting DISABLE_LOGGING_BELOW_LEVEL para definir a "linha de corte", ou deixar habilitado o logging.

FIX: #1188