### PR TITLE
#1195 - remover django-cache-machine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ South
 psycopg2==2.4.1
 wsgiref==0.1.2
 scielo-django-extensions==0.4
-python-memcached==1.48
 ordereddict==1.1
 pillow==2.3.0
 django-widget-tweaks==1.1.1
@@ -14,7 +13,6 @@ yuicompressor
 jsonfield
 django-tastypie==0.9.16
 django-htmlmin==0.7.0
--e git+git://github.com/scieloorg/django-cache-machine.git#egg=django-cache-machine
 packtools
 Celery
 django-celery

--- a/scielomanager/health/checks.py
+++ b/scielomanager/health/checks.py
@@ -1,10 +1,9 @@
-#coding: utf-8
+# coding: utf-8
 import logging
 import uuid
 
 import psycopg2
 from django.db import connections, DatabaseError
-from django.core.cache import cache
 from celery import current_app
 from kombu import Connection
 
@@ -24,6 +23,7 @@ class PGConnection(CheckItem):
             psycopg2.extensions.STATUS_IN_TRANSACTION,
             psycopg2.extensions.STATUS_PREPARED,
     )
+
     def __init__(self):
         self.must_fail = False
 
@@ -53,20 +53,6 @@ class PGConnection(CheckItem):
                 return None
         else:
             return True
-
-
-class CachingBackend(CheckItem):
-    """
-    Connection with the caching backend
-    """
-    def __call__(self):
-        key = uuid.uuid4().hex
-
-        try:
-            ret_code = cache.add(key, '\x01', timeout=1)
-            return bool(ret_code)
-        finally:
-            cache.delete(key)
 
 
 class CeleryConnection(CheckItem):

--- a/scielomanager/health/management/commands/healthd.py
+++ b/scielomanager/health/management/commands/healthd.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 def get_checklist():
     checklist = health.CheckList()
     checklist.add_check(checks.PGConnection())
-    checklist.add_check(checks.CachingBackend())
     checklist.add_check(checks.CeleryConnection())
     checklist.add_check(checks.RabbitConnection())
 
@@ -58,4 +57,3 @@ class Command(BaseCommand):
             server.run()
         except KeyboardInterrupt:
             logger.info('healthd is shutting down')
-

--- a/scielomanager/journalmanager/admin.py
+++ b/scielomanager/journalmanager/admin.py
@@ -21,38 +21,20 @@ class SectionTitleInline(admin.StackedInline):
     model = SectionTitle
 
 
-class StudyAreaAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return StudyArea.nocacheobjects
-
-admin.site.register(StudyArea, StudyAreaAdmin)
+admin.site.register(StudyArea)
 
 
 class CollectionAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Collection.nocacheobjects
-
     list_display = ('name',)
     search_fields = ('name',)
 
 admin.site.register(Collection, CollectionAdmin)
 
 
-class SectionAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Section.nocacheobjects
-
-admin.site.register(Section, SectionAdmin)
+admin.site.register(Section)
 
 
 class JournalAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Journal.nocacheobjects
-
     list_display = ('title',)
     search_fields = ('title',)
     filter_horizontal = ('languages',)
@@ -62,10 +44,6 @@ admin.site.register(Journal, JournalAdmin)
 
 
 class InstitutionAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Institution.nocacheobjects
-
     list_display = ('name',)
     search_fields = ('name',)
 
@@ -73,20 +51,12 @@ admin.site.register(Institution, InstitutionAdmin)
 
 
 class UserCollectionsInline(admin.TabularInline):
-
-    def queryset(self, request):
-        return UserCollections.nocacheobjects
-
     model = UserCollections
     extra = 1
     can_delete = True
 
 
 class UserProfileInline(admin.StackedInline):
-
-    def queryset(self, request):
-        return UserProfile.nocacheobjects
-
     model = UserProfile
     max_num = 1
     can_delete = True
@@ -127,10 +97,6 @@ admin.site.register(User, UserAdmin)
 
 
 class IssueAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Issue.nocacheobjects
-
     search_fields = ('publication_year', 'volume', 'number', 'journal__title')
     list_display = ('journal', 'volume', 'number', 'is_trashed', 'is_marked_up', '__unicode__',)
 
@@ -138,10 +104,6 @@ admin.site.register(Issue, IssueAdmin)
 
 
 class SponsorAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Sponsor.nocacheobjects
-
     filter_horizontal = ('collections',)
 
 admin.site.register(Sponsor, SponsorAdmin)
@@ -149,42 +111,21 @@ admin.site.register(Sponsor, SponsorAdmin)
 
 class UseLicenseAdmin(admin.ModelAdmin):
     list_display = ('license_code', 'is_default', )
-    def queryset(self, request):
-        return UseLicense.nocacheobjects
 
 admin.site.register(UseLicense, UseLicenseAdmin)
-
-
-class LanguageAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return Language.nocacheobjects
-
-admin.site.register(Language, LanguageAdmin)
-
-
-class TranslatedDataAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return TranslatedData.nocacheobjects
-
+admin.site.register(Language)
 admin.site.register(TranslatedData)
+admin.site.register(PressRelease)
 
 
-class PressReleaseAdmin(admin.ModelAdmin):
-
-    def queryset(self, request):
-        return PressRelease.nocacheobjects
-
-admin.site.register(PressRelease, PressReleaseAdmin)
-
-
-#--------
+# --------
 # Article
-#--------
+# --------
+
 def is_linked_to_issue(article):
     return bool(article.issue)
 is_linked_to_issue.boolean = True
+
 
 def is_linked_to_journal(article):
     return bool(article.journal)
@@ -193,16 +134,13 @@ is_linked_to_issue.boolean = True
 
 class ArticleAdmin(admin.ModelAdmin):
     list_display = (
-            'aid', 'xml_version', 'domain_key','updated_at',
+            'aid', 'xml_version', 'domain_key', 'updated_at',
             is_linked_to_issue, is_linked_to_journal,
     )
     list_filter = ('issue__journal',)
     date_hierarchy = 'updated_at'
     actions = ['link_to_issue', 'link_to_journal']
     readonly_fields = ('domain_key', 'xml', 'is_aop', 'xml_version', )
-
-    def queryset(self, request):
-        return Article.nocacheobjects
 
     def link_to_issue(self, request, queryset):
         for article in queryset:

--- a/scielomanager/journalmanager/modelmanagers.py
+++ b/scielomanager/journalmanager/modelmanagers.py
@@ -29,7 +29,6 @@ Custom instance of ``models.query.QuerySet``
 * ``unavailable`` returns all objects marked as trash.
 
 """
-import caching.base
 import models
 from scielomanager.utils import usercontext
 from scielomanager.utils.modelmanagers import UserObjectQuerySet, UserObjectManager

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -3,7 +3,6 @@ import urllib
 import hashlib
 import logging
 import choices
-import caching.base
 from pytz import all_timezones
 from scielomanager import tools
 import datetime
@@ -38,8 +37,6 @@ from scielomanager.utils import base28
 from scielomanager.custom_fields import ContentTypeRestrictedFileField, XMLSPSField
 from . import modelmanagers
 
-#User.__bases__ = (caching.base.CachingMixin, models.Model)
-#User.add_to_class('objects', caching.base.CachingManager())
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +70,7 @@ def get_journals_default_use_license():
         raise ImproperlyConfigured("There is no UseLicense set as default")
 
 
-class AppCustomManager(caching.base.CachingManager):
+class AppCustomManager(models.Manager):
     """
     Domain specific model managers.
     """
@@ -233,7 +230,7 @@ class CollectionCustomManager(AppCustomManager):
         return collections
 
 
-class RegularPressReleaseCustomManager(caching.base.CachingManager):
+class RegularPressReleaseCustomManager(models.Manager):
 
     def by_journal_pid(self, journal_pid):
         """
@@ -270,7 +267,7 @@ class RegularPressReleaseCustomManager(caching.base.CachingManager):
         return preleases_qset.filter(issue__publication_year=year).filter(issue__order=order)
 
 
-class AheadPressReleaseCustomManager(caching.base.CachingManager):
+class AheadPressReleaseCustomManager(models.Manager):
 
     def by_journal_pid(self, journal_pid):
         """
@@ -281,16 +278,13 @@ class AheadPressReleaseCustomManager(caching.base.CachingManager):
         return preleases
 
 
-class Language(caching.base.CachingMixin, models.Model):
+class Language(models.Model):
     """
     Represents ISO 639-1 Language Code and its language name in English. Django
     automaticaly translates language names, if you write them right.
 
     http://en.wikipedia.org/wiki/ISO_639-1_language_matrix
     """
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
     iso_code = models.CharField(_('ISO 639-1 Language Code'), max_length=2)
     name = models.CharField(_('Language Name (in English)'), max_length=64)
 
@@ -304,10 +298,7 @@ class Language(caching.base.CachingMixin, models.Model):
 PROFILE_TIMEZONES_CHOICES = zip(all_timezones, all_timezones)
 
 
-class UserProfile(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class UserProfile(models.Model):
     user = models.OneToOneField(User)
     email_notifications = models.BooleanField("Want to receive email notifications?", default=True)
     tz = models.CharField("Time Zone",  max_length=150, choices=PROFILE_TIMEZONES_CHOICES, default=settings.TIME_ZONE)
@@ -406,13 +397,9 @@ class UserProfile(caching.base.CachingMixin, models.Model):
         return (True, None)
 
 
-class Collection(caching.base.CachingMixin, models.Model):
-    # objects = CollectionCustomManager()
-    # nocacheobjects = models.Manager()
-    # Custom manager
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-    userobjects = modelmanagers.CollectionManager()
+class Collection(models.Model):
+    objects = models.Manager()  # The default manager.
+    userobjects = modelmanagers.CollectionManager()  # Custom manager
 
     collection = models.ManyToManyField(User, related_name='user_collection', through='UserCollections', null=True, blank=True, )
     name = models.CharField(_('Collection Name'), max_length=128, db_index=True, )
@@ -504,10 +491,9 @@ class Collection(caching.base.CachingMixin, models.Model):
             return False
 
 
-class UserCollections(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-    userobjects = modelmanagers.UserCollectionsManager()
+class UserCollections(models.Model):
+    objects = models.Manager()  # The default manager.
+    userobjects = modelmanagers.UserCollectionsManager()  # Custom manager
 
     user = models.ForeignKey(User)
     collection = models.ForeignKey(Collection)
@@ -518,12 +504,9 @@ class UserCollections(caching.base.CachingMixin, models.Model):
         unique_together = ("user", "collection", )
 
 
-class Institution(caching.base.CachingMixin, models.Model):
-
-    # Custom manager
-    objects = models.Manager()
-    nocacheobjects = models.Manager()
-    userobjects = modelmanagers.InstitutionManager()
+class Institution(models.Model):
+    objects = models.Manager()  # The default manager.
+    userobjects = modelmanagers.InstitutionManager()  # Custom manager
 
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
@@ -551,10 +534,8 @@ class Institution(caching.base.CachingMixin, models.Model):
 
 
 class Sponsor(Institution):
-    # Custom manager
-    objects = models.Manager()
-    nocacheobjects = models.Manager()
-    userobjects = modelmanagers.SponsorManager()
+    objects = models.Manager()  # The default manager.
+    userobjects = modelmanagers.SponsorManager()  # Custom manager
 
     collections = models.ManyToManyField(Collection)
 
@@ -562,11 +543,8 @@ class Sponsor(Institution):
         permissions = (("list_sponsor", "Can list Sponsors"),)
 
 
-class SubjectCategory(caching.base.CachingMixin, models.Model):
-
-    # Custom manager
-    objects = JournalCustomManager()
-    nocacheobjects = models.Manager()
+class SubjectCategory(models.Model):
+    objects = JournalCustomManager()  # Custom manager
 
     term = models.CharField(_('Term'), max_length=256, db_index=True)
 
@@ -574,11 +552,7 @@ class SubjectCategory(caching.base.CachingMixin, models.Model):
         return self.term
 
 
-class StudyArea(caching.base.CachingMixin, models.Model):
-
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class StudyArea(models.Model):
     study_area = models.CharField(_('Study Area'), max_length=256,
                                   choices=sorted(choices.SUBJECTS, key=lambda SUBJECTS: SUBJECTS[1]))
 
@@ -586,7 +560,7 @@ class StudyArea(caching.base.CachingMixin, models.Model):
         return self.study_area
 
 
-class Journal(caching.base.CachingMixin, models.Model):
+class Journal(models.Model):
     """
     Represents a Journal that is managed by one SciELO Collection.
 
@@ -598,7 +572,6 @@ class Journal(caching.base.CachingMixin, models.Model):
 
     # Custom manager
     objects = JournalCustomManager()
-    nocacheobjects = models.Manager()
     userobjects = modelmanagers.JournalManager()
 
     # Relation fields
@@ -815,26 +788,19 @@ class JournalTimeline(models.Model):
     created_by = models.ForeignKey(User)
 
 
-class JournalTitle(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
+class JournalTitle(models.Model):
     journal = models.ForeignKey(Journal, related_name='other_titles')
     title = models.CharField(_('Title'), null=False, max_length=128)
     category = models.CharField(_('Title Category'), null=False, max_length=128, choices=sorted(choices.TITLE_CATEGORY, key=lambda TITLE_CATEGORY: TITLE_CATEGORY[1]))
 
 
-class JournalMission(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
+class JournalMission(models.Model):
     journal = models.ForeignKey(Journal, related_name='missions')
     description = models.TextField(_('Mission'))
     language = models.ForeignKey('Language', blank=False, null=True)
 
 
-class UseLicense(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class UseLicense(models.Model):
     license_code = models.CharField(_('License Code'), unique=True, null=False, blank=False, max_length=64)
     reference_url = models.URLField(_('License Reference URL'), null=True, blank=True)
     disclaimer = models.TextField(_('Disclaimer'), null=True, blank=True, max_length=512)
@@ -868,9 +834,7 @@ class UseLicense(caching.base.CachingMixin, models.Model):
         super(UseLicense, self).save(*args, **kwargs)
 
 
-class TranslatedData(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
+class TranslatedData(models.Model):
     translation = models.CharField(_('Translation'), null=True, blank=True, max_length=512)
     language = models.CharField(_('Language'), choices=sorted(choices.LANGUAGE, key=lambda LANGUAGE: LANGUAGE[1]), null=False, blank=False, max_length=32)
     model = models.CharField(_('Model'), null=False, blank=False, max_length=32)
@@ -880,10 +844,7 @@ class TranslatedData(caching.base.CachingMixin, models.Model):
         return self.translation if self.translation is not None else 'Missing trans: {0}.{1}'.format(self.model, self.field)
 
 
-class SectionTitle(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class SectionTitle(models.Model):
     section = models.ForeignKey('Section', related_name='titles')
     title = models.CharField(_('Title'), max_length=256, null=False)
     language = models.ForeignKey('Language')
@@ -892,7 +853,7 @@ class SectionTitle(caching.base.CachingMixin, models.Model):
         ordering = ['title']
 
 
-class Section(caching.base.CachingMixin, models.Model):
+class Section(models.Model):
     """
     Represents a multilingual section of one/many Issues of
     a given Journal.
@@ -903,7 +864,6 @@ class Section(caching.base.CachingMixin, models.Model):
     """
     # Custom manager
     objects = SectionCustomManager()
-    nocacheobjects = models.Manager()
     userobjects = modelmanagers.SectionManager()
 
     journal = models.ForeignKey(Journal)
@@ -988,11 +948,10 @@ class Section(caching.base.CachingMixin, models.Model):
             self._create_code(*args, **kwargs)
 
 
-class Issue(caching.base.CachingMixin, models.Model):
+class Issue(models.Model):
 
     # Custom manager
     objects = IssueCustomManager()
-    nocacheobjects = models.Manager()
     userobjects = modelmanagers.IssueManager()
 
     section = models.ManyToManyField(Section, blank=True)
@@ -1058,7 +1017,7 @@ class Issue(caching.base.CachingMixin, models.Model):
     @property
     def publication_date(self):
         start = self.get_publication_start_month_display()
-        end =  self.get_publication_end_month_display()
+        end = self.get_publication_end_month_display()
         if start and end:
             return '{0}/{1} {2}'.format(start[:3], end[:3], self.publication_year)
         elif start:
@@ -1074,7 +1033,7 @@ class Issue(caching.base.CachingMixin, models.Model):
             prefixed_number = 'suppl.%s' % self.suppl_text
         elif self.type == 'special':
             prefixed_number = 'spe.%s' % self.spe_text
-        else: # regular
+        else:  # regular
             prefixed_number = 'n.%s' % self.number
         return 'vol.%s %s' % (self.volume, prefixed_number)
 
@@ -1108,7 +1067,7 @@ class Issue(caching.base.CachingMixin, models.Model):
         issue = self.verbose_identification
         city = self.journal.publication_city
         dates = self.publication_date
-        return '%s %s %s %s'% (abrev_title, issue, city, dates)
+        return '%s %s %s %s' % (abrev_title, issue, city, dates)
 
     def _suggest_order(self, force=False):
         """
@@ -1122,7 +1081,7 @@ class Issue(caching.base.CachingMixin, models.Model):
         When force ``True`` this method ignore order attribute from the instance
         and return the suggest order.
         """
-        if self.order and force == False:
+        if self.order and force is False:
             return self.order
 
         filters = {
@@ -1158,28 +1117,20 @@ class Issue(caching.base.CachingMixin, models.Model):
         super(Issue, self).save(*args, **kwargs)
 
 
-class IssueTitle(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
+class IssueTitle(models.Model):
     issue = models.ForeignKey(Issue)
     language = models.ForeignKey('Language')
     title = models.CharField(_('Title'), max_length=256)
 
 
-class PendedForm(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class PendedForm(models.Model):
     view_name = models.CharField(max_length=128)
     form_hash = models.CharField(max_length=32)
     user = models.ForeignKey(User, related_name='pending_forms')
     created_at = models.DateTimeField(auto_now=True)
 
 
-class PendedValue(caching.base.CachingMixin, models.Model):
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
-
+class PendedValue(models.Model):
     form = models.ForeignKey(PendedForm, related_name='data')
     name = models.CharField(max_length=255)
     value = models.TextField()
@@ -1199,15 +1150,13 @@ class DataChangeEvent(models.Model):
     collection = models.ForeignKey(Collection)
 
 
-class PressRelease(caching.base.CachingMixin, models.Model):
+class PressRelease(models.Model):
     """
     Represents a press-release bound to a Journal.
     If ``issue`` is None, the pressrelease is refers to an ahead article.
     It can be available in one or any languages (restricted by the Journal
     publishing policy).
     """
-    nocacheobjects = models.Manager()
-    objects = models.Manager()
     doi = models.CharField(_("Press release DOI number"),
                            max_length=128, null=True, blank=True)
 
@@ -1280,24 +1229,20 @@ class PressRelease(caching.base.CachingMixin, models.Model):
         permissions = (("list_pressrelease", "Can list PressReleases"),)
 
 
-class PressReleaseTranslation(caching.base.CachingMixin, models.Model):
+class PressReleaseTranslation(models.Model):
     """
     Represents a press-release in a given language.
     """
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
     press_release = models.ForeignKey(PressRelease, related_name='translations')
     language = models.ForeignKey('Language')
     title = models.CharField(_('Title'), max_length=128)
     content = models.TextField(_('Content'))
 
 
-class PressReleaseArticle(caching.base.CachingMixin, models.Model):
+class PressReleaseArticle(models.Model):
     """
     Represents press-releases bound to Articles.
     """
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
     press_release = models.ForeignKey(PressRelease, related_name='articles')
     article_pid = models.CharField(_('PID'), max_length=32, db_index=True)
 
@@ -1316,7 +1261,7 @@ class AheadPressRelease(PressRelease):
     journal = models.ForeignKey(Journal, related_name='press_releases')
 
 
-class Article(caching.base.CachingMixin, models.Model):
+class Article(models.Model):
     """
     Artigo associado ou não a um periódico ou fascículo.
 
@@ -1327,8 +1272,7 @@ class Article(caching.base.CachingMixin, models.Model):
         - https://code.djangoproject.com/ticket/19463
         - https://github.com/django/django/commit/ed7821231b7dbf34a6c8ca65be3b9bcbda4a0703
     """
-    objects = caching.base.CachingManager()
-    nocacheobjects = models.Manager()
+    objects = models.Manager()  # The default manager.
     userobjects = modelmanagers.ArticleManager()
 
     created_at = models.DateTimeField(auto_now_add=True, default=datetime.datetime.now)
@@ -1543,4 +1487,3 @@ def disconnect_article_post_save_signals():
 
 # Callback da tasty-pie para a geração de token para os usuários
 models.signals.post_save.connect(create_api_key, sender=User)
-

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -359,10 +359,6 @@ def toggle_active_collection(request, user_id, collection_id):
     # Setting up all user collections.is_default to False
     user_collections = models.get_user_collections(request.user.id)
 
-    # Clear cache when changes in UserCollections
-    invalid = [collection for collection in user_collections]
-    models.UserCollections.objects.invalidate(*invalid)
-
     collection = get_object_or_404(models.Collection, pk=collection_id)
     collection.make_default_to_user(request.user)
 
@@ -500,10 +496,6 @@ def add_user(request, user_id=None):
 
         if userform.is_valid() and usercollectionsformset.is_valid() and userprofileformset.is_valid():
             new_user = userform.save()
-
-            # Clear cache when changes in UserCollections
-            invalid = [collection for collection in user_collections]
-            models.UserCollections.objects.invalidate(*invalid)
 
             # force the first instance (collection) to be set as default
             instances = usercollectionsformset.save(commit=False)

--- a/scielomanager/maintenancewindow/models.py
+++ b/scielomanager/maintenancewindow/models.py
@@ -2,10 +2,8 @@ from datetime import date
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-import caching.base
 
-
-class EventManager(caching.base.CachingManager):
+class EventManager(models.Manager):
 
     def scheduled_events(self, actual_date=date.today()):
         """
@@ -28,7 +26,7 @@ class EventManager(caching.base.CachingManager):
         self.filter(is_blocking_users=True).update(is_blocking_users=False)
 
 
-class Event(caching.base.CachingMixin, models.Model):
+class Event(models.Model):
 
     objects = EventManager()
     title = models.CharField(_('Title'), max_length=128, null=False, blank=False)
@@ -36,10 +34,9 @@ class Event(caching.base.CachingMixin, models.Model):
     end_at = models.DateTimeField(_('End at'), null=False, blank=False, db_index=True)
     description = models.TextField(_('Description'), null=False, blank=False)
     is_blocking_users = models.BooleanField(_('is blocking users'),
-                        default=False,
-                        db_index=True,
-                        help_text=_('once it is checked, it will set up the other events to false')
-                        )
+                                            default=False,
+                                            db_index=True,
+                                            help_text=_('once it is checked, it will set up the other events to false'))
     is_finished = models.BooleanField(_('Is finished'), default=False)
     event_report = models.TextField(_('Report'), blank=True)
 

--- a/scielomanager/scielomanager/settings.py
+++ b/scielomanager/scielomanager/settings.py
@@ -281,13 +281,6 @@ SECTION_CODE_TOTAL_RANDOM_CHARS = 4
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
-CACHES = {
-    'default': {
-        # 'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        'LOCATION': '',
-    }
-}
 
 IMAGE_CONTENT_TYPE = ['image/jpg', 'image/jpeg', 'image/gif', 'image/png']
 IMAGE_DIMENSIONS = {

--- a/scielomanager/scielomanager/settings_local.include-TEMPLATE
+++ b/scielomanager/scielomanager/settings_local.include-TEMPLATE
@@ -23,16 +23,6 @@ EMAIL_HOST_PASSWORD = ''
 EMAIL_SUBJECT_PREFIX = '[SciELO Manager] - DO NOT REPLY -'
 DEFAULT_FROM_EMAIL = ''
 
-CACHES = {
-    'default': {
-        'BACKEND': 'caching.backends.memcached.MemcachedCache',
-        'LOCATION': [
-            '127.0.0.1:11211',
-        ],
-        'PREFIX': 'scielomanager:',
-    },
-}
-
 #
 # Full qualified path to the class responsible for returning active user context
 #

--- a/scielomanager/scielomanager/settings_tests.py
+++ b/scielomanager/scielomanager/settings_tests.py
@@ -9,13 +9,6 @@ PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))
 execfile(os.path.join(PROJECT_PATH, 'settings.py'))
 
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        'LOCATION': '',
-    }
-}
-
 INSTALLED_APPS += (
     'api',
 )

--- a/scielomanager/scielomanager/utils/modelmanagers/base.py
+++ b/scielomanager/scielomanager/utils/modelmanagers/base.py
@@ -29,10 +29,10 @@ Custom instance of ``models.query.QuerySet``
 * ``unavailable`` returns all objects marked as trash.
 
 """
-import caching.base
+from django.db import models
 
 
-class UserObjectQuerySet(caching.base.CachingQuerySet):
+class UserObjectQuerySet(models.query.QuerySet):
     """
     Provides a basic implementation of userobject querysets with
     caching features.
@@ -44,7 +44,7 @@ class UserObjectQuerySet(caching.base.CachingQuerySet):
         return self.none()
 
 
-class UserObjectManager(caching.base.CachingManager):
+class UserObjectManager(models.Manager):
     """
     Provides a basic implementation of userobject managers with
     caching features.


### PR DESCRIPTION
FIXES: #1195

- faltaria reformar ``scielomanager/utils/modelmanagers/base.py`` mas pode ser uma tarefa independente, junto com a reorganização dos modelmanagers.
- lembrar que tem que desinstalar as dependencias removidas do ``requirements.txt`` com  ``pip uninstall ...``