### PR TITLE
Relacionamento recursivo entre entidades do tipo Article

### DIFF
--- a/scielomanager/journalmanager/migrations/0004_auto__add_linkbetweenarticles__add_field_article_article_type.py
+++ b/scielomanager/journalmanager/migrations/0004_auto__add_linkbetweenarticles__add_field_article_article_type.py
@@ -1,0 +1,415 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'LinkBetweenArticles'
+        db.create_table('journalmanager_linkbetweenarticles', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('referrer', self.gf('django.db.models.fields.related.ForeignKey')(related_name='links_to', to=orm['journalmanager.Article'])),
+            ('link_to', self.gf('django.db.models.fields.related.ForeignKey')(related_name='referrers', to=orm['journalmanager.Article'])),
+            ('link_type', self.gf('django.db.models.fields.CharField')(max_length=32)),
+        ))
+        db.send_create_signal('journalmanager', ['LinkBetweenArticles'])
+
+        # Adding field 'Article.links_to_related_articles_are_pending'
+        db.add_column('journalmanager_article', 'links_to_related_articles_are_pending',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Article.doi'
+        db.add_column('journalmanager_article', 'doi',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=2048, db_index=True),
+                      keep_default=False)
+
+        # Adding field 'Article.article_type'
+        db.add_column('journalmanager_article', 'article_type',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=32, db_index=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'LinkBetweenArticles'
+        db.delete_table('journalmanager_linkbetweenarticles')
+
+        # Deleting field 'Article.links_to_related_articles_are_pending'
+        db.delete_column('journalmanager_article', 'links_to_related_articles_are_pending')
+
+        # Deleting field 'Article.doi'
+        db.delete_column('journalmanager_article', 'doi')
+
+        # Deleting field 'Article.article_type'
+        db.delete_column('journalmanager_article', 'article_type')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.aheadpressrelease': {
+            'Meta': {'object_name': 'AheadPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Journal']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.article': {
+            'Meta': {'object_name': 'Article'},
+            'aid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'article_type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'db_index': 'True'}),
+            'domain_key': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '2048', 'db_index': 'False'}),
+            'es_is_dirty': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'es_updated_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_aop': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'issn_epub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issn_ppub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Issue']"}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'journal_title': ('django.db.models.fields.CharField', [], {'max_length': '512', 'db_index': 'True'}),
+            'links_to_related_articles_are_pending': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'related_articles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['journalmanager.Article']", 'null': 'True', 'through': "orm['journalmanager.LinkBetweenArticles']", 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'xml': ('scielomanager.custom_fields.XMLSPSField', [], {}),
+            'xml_version': ('django.db.models.fields.CharField', [], {'max_length': '9'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.datachangeevent': {
+            'Meta': {'object_name': 'DataChangeEvent'},
+            'changed_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.issue': {
+            'Meta': {'ordering': "('created', 'id')", 'object_name': 'Issue'},
+            'cover': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_marked_up': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'label': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'blank': 'True'}),
+            'publication_end_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_start_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_year': ('django.db.models.fields.IntegerField', [], {}),
+            'section': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Section']", 'symmetrical': 'False', 'blank': 'True'}),
+            'spe_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'suppl_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'total_documents': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'regular'", 'max_length': '15'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']", 'null': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'})
+        },
+        'journalmanager.issuetitle': {
+            'Meta': {'object_name': 'IssueTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Issue']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'editor_journal'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.journalmission': {
+            'Meta': {'object_name': 'JournalMission'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'missions'", 'to': "orm['journalmanager.Journal']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']", 'null': 'True'})
+        },
+        'journalmanager.journaltimeline': {
+            'Meta': {'object_name': 'JournalTimeline'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'since': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'journalmanager.journaltitle': {
+            'Meta': {'object_name': 'JournalTitle'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'other_titles'", 'to': "orm['journalmanager.Journal']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.linkbetweenarticles': {
+            'Meta': {'object_name': 'LinkBetweenArticles'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link_to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'referrers'", 'to': "orm['journalmanager.Article']"}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'referrer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links_to'", 'to': "orm['journalmanager.Article']"})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.pendedform': {
+            'Meta': {'object_name': 'PendedForm'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_forms'", 'to': "orm['auth.User']"}),
+            'view_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.pendedvalue': {
+            'Meta': {'object_name': 'PendedValue'},
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'data'", 'to': "orm['journalmanager.PendedForm']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'journalmanager.pressrelease': {
+            'Meta': {'object_name': 'PressRelease'},
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.pressreleasearticle': {
+            'Meta': {'object_name': 'PressReleaseArticle'},
+            'article_pid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.PressRelease']"})
+        },
+        'journalmanager.pressreleasetranslation': {
+            'Meta': {'object_name': 'PressReleaseTranslation'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'to': "orm['journalmanager.PressRelease']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.regularpressrelease': {
+            'Meta': {'object_name': 'RegularPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Issue']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.section': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Section'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '21', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'legacy_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'journalmanager.sectiontitle': {
+            'Meta': {'ordering': "['title']", 'object_name': 'SectionTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'titles'", 'to': "orm['journalmanager.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.translateddata': {
+            'Meta': {'object_name': 'TranslatedData'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'translation': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'email_notifications': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tz': ('django.db.models.fields.CharField', [], {'default': "'America/Sao_Paulo'", 'max_length': '150'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['journalmanager']

--- a/scielomanager/journalmanager/migrations/0005_linkbetweenarticles_data_setup.py
+++ b/scielomanager/journalmanager/migrations/0005_linkbetweenarticles_data_setup.py
@@ -45,7 +45,7 @@ class Migration(DataMigration):
             else:
                 article.links_to_related_articles_are_pending = False
 
-        article.save()
+            article.save()
 
 
     def backwards(self, orm):

--- a/scielomanager/journalmanager/migrations/0005_linkbetweenarticles_data_setup.py
+++ b/scielomanager/journalmanager/migrations/0005_linkbetweenarticles_data_setup.py
@@ -1,0 +1,421 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+def get_value(xml, expression):
+    """ Busca `expression` em `xml` e retorna o resultado da primeira ocorrência.
+
+    Função copiada de `journalmanager.models.Article.get_value`.
+
+    Espaços em branco no início ou fim são removidos. Retorna `None` caso
+    `expression` não encontre elementos, ou o elemento esteja vazio.
+    """
+    try:
+        first_occ = xml.xpath(expression)[0]
+    except IndexError:
+        return None
+
+    try:
+        value = first_occ.text
+    except AttributeError:
+        # valor de atributo
+        value = first_occ
+
+    try:
+        return value.strip()
+    except AttributeError:
+        return value
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        DOI = '/article/front/article-meta/article-id[@pub-id-type="doi"]'
+        ARTICLE_TYPE = '/article/@article-type'
+
+        for article in orm.Article.objects.only('xml').filter(doi=u''):
+            article.doi = get_value(article.xml, DOI) or u''
+            article.article_type = get_value(article.xml, ARTICLE_TYPE) or u'undefined'
+
+            if article.article_type in ['correction', 'article-commentary']:
+                article.links_to_related_articles_are_pending = True
+            else:
+                article.links_to_related_articles_are_pending = False
+
+        article.save()
+
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.aheadpressrelease': {
+            'Meta': {'object_name': 'AheadPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Journal']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.article': {
+            'Meta': {'object_name': 'Article'},
+            'aid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'article_type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'db_index': 'True', 'default': "''"}),
+            'domain_key': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '2048', 'db_index': 'False'}),
+            'es_is_dirty': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'es_updated_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_aop': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'issn_epub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issn_ppub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Issue']"}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'journal_title': ('django.db.models.fields.CharField', [], {'max_length': '512', 'db_index': 'True'}),
+            'links_to_related_articles_are_pending': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'related_articles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['journalmanager.Article']", 'null': 'True', 'through': "orm['journalmanager.LinkBetweenArticles']", 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'xml': ('scielomanager.custom_fields.XMLSPSField', [], {}),
+            'xml_version': ('django.db.models.fields.CharField', [], {'max_length': '9'})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.datachangeevent': {
+            'Meta': {'object_name': 'DataChangeEvent'},
+            'changed_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.issue': {
+            'Meta': {'ordering': "('created', 'id')", 'object_name': 'Issue'},
+            'cover': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_marked_up': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'label': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'blank': 'True'}),
+            'publication_end_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_start_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_year': ('django.db.models.fields.IntegerField', [], {}),
+            'section': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Section']", 'symmetrical': 'False', 'blank': 'True'}),
+            'spe_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'suppl_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'total_documents': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'regular'", 'max_length': '15'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']", 'null': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'})
+        },
+        'journalmanager.issuetitle': {
+            'Meta': {'object_name': 'IssueTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Issue']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'editor_journal'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'national_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'max_length': '254', 'null': 'True', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.journalmission': {
+            'Meta': {'object_name': 'JournalMission'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'missions'", 'to': "orm['journalmanager.Journal']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']", 'null': 'True'})
+        },
+        'journalmanager.journaltimeline': {
+            'Meta': {'object_name': 'JournalTimeline'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'since': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'journalmanager.journaltitle': {
+            'Meta': {'object_name': 'JournalTitle'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'other_titles'", 'to': "orm['journalmanager.Journal']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.linkbetweenarticles': {
+            'Meta': {'object_name': 'LinkBetweenArticles'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link_to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'referrers'", 'to': "orm['journalmanager.Article']"}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'referrer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links_to'", 'to': "orm['journalmanager.Article']"})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.pendedform': {
+            'Meta': {'object_name': 'PendedForm'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_forms'", 'to': "orm['auth.User']"}),
+            'view_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.pendedvalue': {
+            'Meta': {'object_name': 'PendedValue'},
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'data'", 'to': "orm['journalmanager.PendedForm']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'journalmanager.pressrelease': {
+            'Meta': {'object_name': 'PressRelease'},
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.pressreleasearticle': {
+            'Meta': {'object_name': 'PressReleaseArticle'},
+            'article_pid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.PressRelease']"})
+        },
+        'journalmanager.pressreleasetranslation': {
+            'Meta': {'object_name': 'PressReleaseTranslation'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'to': "orm['journalmanager.PressRelease']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.regularpressrelease': {
+            'Meta': {'object_name': 'RegularPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Issue']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.section': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Section'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '21', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'legacy_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'journalmanager.sectiontitle': {
+            'Meta': {'ordering': "['title']", 'object_name': 'SectionTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'titles'", 'to': "orm['journalmanager.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.translateddata': {
+            'Meta': {'object_name': 'TranslatedData'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'translation': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'email_notifications': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tz': ('django.db.models.fields.CharField', [], {'default': "'America/Sao_Paulo'", 'max_length': '150'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['journalmanager']
+    symmetrical = True

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -1197,6 +1197,27 @@ class AheadPressRelease(PressRelease):
     journal = models.ForeignKey(Journal, related_name='press_releases')
 
 
+class LinkBetweenArticles(models.Model):
+    """ Relação entre entidades do tipo `Article`.
+
+    Representa a relação que no XML é realizada por meio do elemento
+    `related-article`.
+
+      - `referrer` é a instância de `Article` que remete à outra.
+      - `link_to` é a instância de `Article` referida pela outra.
+      - `link_type` é o tipo da relação, que pode ser: corrected-article ou
+        commentary-article.
+    """
+    referrer = models.ForeignKey('Article', related_name='links_to')
+    link_to = models.ForeignKey('Article', related_name='referrers')
+    link_type = models.CharField(max_length=32)
+
+    def __repr__(self):
+        return u'<%s referrer="%s" link_to="%s" link_type="%s">' % (
+                self.__class__.__name__, self.referrer, self.link_to,
+                self.link_type)
+
+
 class Article(models.Model):
     """
     Artigo associado ou não a um periódico ou fascículo.
@@ -1215,17 +1236,22 @@ class Article(models.Model):
     updated_at = models.DateTimeField(auto_now=True, default=datetime.datetime.now)
     es_updated_at = models.DateTimeField(null=True, blank=True)  # elasticsearch
     es_is_dirty = models.BooleanField(default=True)
+    links_to_related_articles_are_pending = models.BooleanField(default=False)
 
     aid = models.CharField(max_length=32, unique=True, editable=False)
+    doi = models.CharField(max_length=2048, default=u'', db_index=True)
     domain_key = models.SlugField(max_length=2048, unique=True, db_index=False, editable=False)
     is_visible = models.BooleanField(default=True)
     is_aop = models.BooleanField(default=False)
     xml = XMLSPSField()
     xml_version = models.CharField(max_length=9)
+    article_type = models.CharField(max_length=32, db_index=True)
 
     # artigo pode estar temporariamente desassociado de seu periódico e fascículo
     journal = models.ForeignKey(Journal, related_name='articles', blank=True, null=True)
     issue = models.ForeignKey(Issue, related_name='articles', blank=True, null=True)
+    related_articles = models.ManyToManyField('self', through='LinkBetweenArticles',
+            symmetrical=False, blank=True, null=True)
     journal_title = models.CharField(_('Journal title'), max_length=512, db_index=True)
     issn_ppub = models.CharField(max_length=9, db_index=True)
     issn_epub = models.CharField(max_length=9, db_index=True)
@@ -1257,6 +1283,8 @@ class Article(models.Model):
         PID = '/article/front/article-meta/article-id[@pub-id-type="publisher-id"]'
         ARTICLE_TYPE = '/article/@article-type'
         AOP_ID = '/article/front/article-meta/article-id[@pub-id-type="other"]'
+        RELATED_CORRECTED_ARTICLES = '/article/front/article-meta/related-article[@related-article-type="corrected-article"]'
+        RELATED_COMMENTARY_ARTICLES = '/article/response/front-stub/related-article[@related-article-type="commentary-article"]'
 
     def save(self, *args, **kwargs):
         """
@@ -1278,12 +1306,20 @@ class Article(models.Model):
             self.issn_epub = self.get_value(self.XPaths.ISSN_EPUB) or ''
             self.xml_version = self.get_value(self.XPaths.SPS_VERSION) or 'pre-sps'
             self.aid = str(uuid4().hex)
+            self.article_type = self.get_value(self.XPaths.ARTICLE_TYPE)
+            self.doi = self.get_value(self.XPaths.DOI) or ''
 
             if not any([self.issn_ppub, self.issn_epub]):
                 raise ValueError('Either issn_ppub or issn_epub must be set')
 
             if not self.journal_title:
                 raise ValueError('Could not get journal-title from %s' % self)
+
+            if not self.article_type:
+                raise ValueError('Could not get article-type from %s' % self)
+
+            if self.article_type in ['correction', 'article-commentary']:
+                self.links_to_related_articles_are_pending = True
 
         super(Article, self).save(*args, **kwargs)
 
@@ -1374,6 +1410,16 @@ class Article(models.Model):
         text_values = (value if value else 'none' for value in values)
         joined_values = '_'.join(text_values)
         return slugify(joined_values)
+
+    #def add_link_to_article(self, target, link_type):
+    #    """ Cria relação com outra entidade tipo `Article`.
+    #    """
+    #    LinkBetweenArticles.objects.create(
+    #            referrer=self, link_to=target, link_type=link_type)
+
+    def __repr__(self):
+        return u'<%s aid="%s" domain_key="%s">' % (self.__class__.__name__,
+                self.aid, self.domain_key)
 
 
 # --------------------

--- a/scielomanager/journalmanager/tasks.py
+++ b/scielomanager/journalmanager/tasks.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 
 from lxml import isoschematron, etree
 from django.db.models import Q
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from celery.utils.log import get_task_logger
 
 from scielomanager.celery import app
@@ -292,3 +292,63 @@ def rebuild_articles_domain_key():
 
     for article in articles:
         rebuild_article_domain_key.delay(article.pk)
+
+
+@app.task(ignore_result=True)
+def link_article_with_their_related(article_pk):
+    """ Tenta associar artigos relacionados.
+
+    Essa função é idempotente, e pode ser executada inúmeras vezes até
+    que todas as referências de um artigo sejam estabelecidas.
+
+    Caso alguma exceção seja levantada, nenhuma mudança será persistida na
+    base de dados.
+    """
+    try:
+        referrer = models.Article.objects.only('pk', 'xml').get(pk=article_pk,
+                links_to_related_articles_are_pending=True)
+    except models.Article.DoesNotExist:
+        logger.info('Cannot find Article with with pk: %s. Skipping the task.',
+                article_pk)
+        return None
+
+    related_article_elements = (
+            referrer.xml.xpath(referrer.XPaths.RELATED_CORRECTED_ARTICLES) +
+            referrer.xml.xpath(referrer.XPaths.RELATED_COMMENTARY_ARTICLES)
+    )
+
+    doi_type_pairs = ([elem.attrib['{http://www.w3.org/1999/xlink}href'],
+                      elem.attrib['related-article-type']]
+                      for elem in related_article_elements)
+
+    def _ensure_articles_are_linked(doi, rel_type):
+        try:
+            target = models.Article.objects.only('pk').get(doi=doi)
+        except models.Article.DoesNotExist:
+            return False
+
+        models.LinkBetweenArticles.objects.get_or_create(
+                referrer=referrer, link_to=target, link_type=rel_type)
+
+        return True
+
+    with transaction.commit_on_success():
+        link_statuses = (_ensure_articles_are_linked(doi, rel_type)
+                         for doi, rel_type in doi_type_pairs)
+
+        if all(link_statuses):
+            referrer.links_to_related_articles_are_pending = False
+            with avoid_circular_signals(ARTICLE_SAVE_MUTEX):
+                referrer.save()
+
+
+@app.task(ignore_result=True)
+def process_related_articles():
+    """ Tenta associar artigos relacionados.
+    """
+    articles = models.Article.objects.only('pk').filter(
+            links_to_related_articles_are_pending=True)
+
+    for article in articles:
+        link_article_with_their_related.delay(article.pk)
+

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -749,7 +749,7 @@ class UseLicenseTests(TestCase):
 
 
 class ArticleTests(TestCase):
-    sample = u"""<article specific-use="sps-1.2">
+    sample = u"""<article article-type="research-article" specific-use="sps-1.2">
                    <front>
                      <journal-meta>
                        <journal-title-group>
@@ -1108,6 +1108,64 @@ class ArticleXpathsTests(TestCase):
         self.assertEqual(
                 article.xml.xpath(models.Article.XPaths.AOP_ID)[0].text,
                 u'xpto')
+
+    def test_related_articles(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article"
+                                            id="ra1"
+                                            xlink:href="10.1590/abd1806-4841.20142998"
+                                            ext-link-type="doi"/>
+                           <related-article related-article-type="corrected-article"
+                                            id="ra1"
+                                            xlink:href="10.1590/abd1806-4841.20142999"
+                                            ext-link-type="doi"/>
+                         </article-meta>
+                       </front>
+                     </article>"""
+
+        article = models.Article(xml=sample)
+        rel_articles = article.xml.xpath(models.Article.XPaths.RELATED_CORRECTED_ARTICLES)
+
+        self.assertEqual(len(rel_articles), 2)
+        self.assertEqual(
+                rel_articles[0].attrib['{http://www.w3.org/1999/xlink}href'],
+                '10.1590/abd1806-4841.20142998')
+        self.assertEqual(
+                rel_articles[1].attrib['{http://www.w3.org/1999/xlink}href'],
+                '10.1590/abd1806-4841.20142999')
+
+    def test_related_articles_at_response(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                       <front>
+                         <article-meta>
+                         </article-meta>
+                       </front>
+                       <response>
+                         <front-stub>
+                           <related-article related-article-type="commentary-article"
+                                            id="ra1"
+                                            xlink:href="10.1590/abd1806-4841.20142998"
+                                            ext-link-type="doi"/>
+                           <related-article related-article-type="commentary-article"
+                                            id="ra1"
+                                            xlink:href="10.1590/abd1806-4841.20142999"
+                                            ext-link-type="doi"/>
+                         </front-stub>
+                       </response>
+                     </article>"""
+
+        article = models.Article(xml=sample)
+        rel_articles = article.xml.xpath(models.Article.XPaths.RELATED_COMMENTARY_ARTICLES)
+
+        self.assertEqual(len(rel_articles), 2)
+        self.assertEqual(
+                rel_articles[0].attrib['{http://www.w3.org/1999/xlink}href'],
+                '10.1590/abd1806-4841.20142998')
+        self.assertEqual(
+                rel_articles[1].attrib['{http://www.w3.org/1999/xlink}href'],
+                '10.1590/abd1806-4841.20142999')
 
 
 class ArticleDomainKeyTests(TestCase):

--- a/scielomanager/journalmanager/tests/tests_tasks.py
+++ b/scielomanager/journalmanager/tests/tests_tasks.py
@@ -600,7 +600,7 @@ class ArticleMetaElementsTests(PhaseBasedTestCase):
 
 
 class FunctionAddFromStringTests(TestCase):
-    sample = u"""<article>
+    sample = u"""<article article-type="research-article">
                    <front>
                      <journal-meta>
                        <journal-title-group>

--- a/scielomanager/scielomanager/celery.py
+++ b/scielomanager/scielomanager/celery.py
@@ -33,7 +33,13 @@ CELERYBEAT_SCHEDULE = {
         'task': 'journalmanager.tasks.process_dirty_articles',
         'schedule': crontab(minute=0, hour=2),
         'args': ()
-    }
+    },
+    # Executa durante horário de trabalho desde utc+2 à utc-7
+    'process-related-articles-working-hours': {
+        'task': 'journalmanager.tasks.process_related_articles',
+        'schedule': crontab(minute=0, hour='2-20', day_of_week='mon-fri'),
+        'args': ()
+    },
 }
 app.conf.update(
     CELERYBEAT_SCHEDULE=CELERYBEAT_SCHEDULE,


### PR DESCRIPTION
Closes #1216.

Adicionado o atributo de controle *Article.links_to_related_articles_are_pending*
para coordenar a operação das tasks periódicas:
*journalmanager.tasks.link_article_with_their_related* e
*journalmanager.tasks.process_related_articles*, para a identificação e
estabelecimento das associações entre os artigos.