### PR TITLE
Pequenos ajustes na visualização dos artigos.

### DIFF
--- a/scielomanager/journalmanager/templates/journalmanager/article_detail.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_detail.html
@@ -35,22 +35,40 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li class="active">
-                    <a data-toggle="tab" href="#xml_content">
-                        {% trans "XML content" %}:
-                    </a>
-                </li>
                 {# adiciono uma tab para cada linguagem/html gerado #}
                 {% for preview in previews %}
-                    <li>
+                    <li {% if forloop.first %}class="active"{% endif %}>
                         <a data-toggle="tab" href="#preview_{{ preview.lang }}">
                             {% trans "HTML preview" %} ({{ preview.lang|upper }})
                         </a>
                     </li>
+                {% empty %}
+                    <li class="active">
+                        <a data-toggle="tab" href="#preview_unavailable">
+                            {% trans "HTML preview" %}
+                        </a>
+                    </li>
                 {% endfor %}
+                <li>
+                    <a data-toggle="tab" href="#xml_content">
+                        {% trans "Source XML" %}
+                    </a>
+                </li>
             </ul>
             <div class="tab-content">
-                <div class="tab-pane active" id="xml_content">
+                {# adiciono uma tab-pane para cada linguagem/html gerado #}
+                {% for preview in previews %}
+                    <div class="tab-pane tab-pane-preview {% if forloop.first %}active{% endif %}" id="preview_{{ preview.lang }}">
+                        <div class="preview_container">
+                            <iframe id="iframe_{{preview.lang}}" scrolling="auto" src='' width="100%" height="1000px" frameborder="0"></iframe>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="tab-pane tab-pane-preview active" id="preview_unavailable">
+                        <p>{% trans "Sorry, but the HTML preview is not available for this article." %}</p>
+                    </div>
+                {% endfor %}
+                <div class="tab-pane" id="xml_content">
                     <div class="codemirror_wrapper">
                         {% if article.xml %}
                             <textarea id="code" name="code">{{ article.xml }}</textarea>
@@ -59,14 +77,6 @@
                         {% endif %}
                     </div>
                 </div>
-                {# adiciono uma tab-pane para cada linguagem/html gerado #}
-                {% for preview in previews %}
-                    <div class="tab-pane tab-pane-preview" id="preview_{{ preview.lang }}">
-                        <div class="preview_container">
-                            <iframe id="iframe_{{preview.lang}}" scrolling="auto" src='' width="100%" height="1000px" frameborder="0"></iframe>
-                        </div>
-                    </div>
-                {% endfor %}
             </div>
         </div>
     </div>

--- a/scielomanager/journalmanager/templates/journalmanager/article_list.html
+++ b/scielomanager/journalmanager/templates/journalmanager/article_list.html
@@ -23,7 +23,7 @@
     </tr>
   </thead>
   <tbody>
-    {% regroup articles by xml_head_subject as articles_list %}
+    {% regroup articles by HEAD_SUBJECT as articles_list %}
     {% for article_set in articles_list %}
       <tr class="grey_bg">
         <td>

--- a/scielomanager/journalmanager/views.py
+++ b/scielomanager/journalmanager/views.py
@@ -310,14 +310,17 @@ def article_detail(request, article_pk):
     article = get_object_or_404(models.Article.userobjects.active(), pk=article_pk)
     previews = []
 
-    if article.xml and not article.is_aop:
+    if article.xml:
+        css_url = static('css/htmlgenerator/styles.css')
+
         try:
-            css_url = static('css/htmlgenerator/styles.css')
-            for lang, html_output in packtools.HTMLGenerator(article.xml.root_etree, valid_only=False, css=css_url):
-                previews.append({'lang': lang, 'html': html_output})
+            html_generator = packtools.HTMLGenerator(article.xml.root_etree,
+                    valid_only=False, css=css_url)
+            previews = [{'lang': lang, 'html': html}
+                        for lang, html in html_generator]
+
         except Exception:
-            # qualquer exeção aborta a pre-visualização mas continua com o resto
-            previews = []
+            pass
 
     return render_to_response(
         'journalmanager/article_detail.html',


### PR DESCRIPTION
* Agrupamento por ``HEAD_SUBJECT`` na listagem de artigos do número;
* Removida restrição que impedia a pré-visualização em HTML de artigos
  em AOP;
* Pré-visualização aparece primeiro do conteúdo XML, pois é mais *user
  friendly*, nos detalhes de um artigo;
* Ajuste na view-function para tornar o código mais idiomático.