### PR TITLE
Armazenamento de ativos estáticos vinculados aos artigos.

### DIFF
--- a/docs/dev/rpc_spec/addArticleAsset.rst
+++ b/docs/dev/rpc_spec/addArticleAsset.rst
@@ -1,0 +1,47 @@
+.. _func-addArticleAsset:
+
+``void addArticleAsset(1:string aid, 2:string filename, 3:binary content, 4:ArticleAssetMeta meta) throws (1:ServerError srv_err);``
+====================================================================================================================================
+
+Cadastra uma nova entidade ``journalmanager.models.ArticleAsset``, vinculada à 
+instância de ``journalmanager.models.Article`` definida pelo argumento ``aid``. 
+
+
+Resumo
+------
+
+O sistema deve permitir que essas entidades sejam cadastradas de maneira programática, por softwares do 
+fluxo de ingestão. 
+
+A função deve ser assíncrona, a fim de que o serviço seja resiliente e atenda um número 
+arbitrário de requisições com tempo de resposta virtualmente constante. O resultado 
+da sua execução deve ser consultado por meio do uso do identificador ``task_id``. 
+Ver documentação da função :ref:`func-getTaskResult`.
+
+Os resultados possíveis são:
+
++----------------------------------------+-------------------------------------------------------------+
+| Estado                                 | Objeto retornado                                            |
++========================================+=============================================================+
+| A função está pendente de execução     | AsyncResult(status=PENDING, value='')                       | 
++----------------------------------------+-------------------------------------------------------------+
+| A função está em execução              | AsyncResult(status=STARTED, value='')                       |
++----------------------------------------+-------------------------------------------------------------+
+| A função falhou e está aguardando nova | AsyncResult(status=RETRY, value='')                         |
+| execução                               |                                                             |
++----------------------------------------+-------------------------------------------------------------+
+| A função falhou definitivamente        | AsyncResult(status=FAILURE, value='[errno, "err_message"]') |
++----------------------------------------+-------------------------------------------------------------+
+| A função foi executada com sucesso     | AsyncResult(status=SUCCESS, value='asset_url')              |
++----------------------------------------+-------------------------------------------------------------+
+
+
+No caso de resultados com status ``FAILURE``, os valores para ``errno`` são:
+
++-------+------------------+----------------------------------------------------------+
+| errno | Tipo             | Descrição                                                |
++=======+==================+==========================================================+
+| 2     | ValueError       | ``aid`` não corresponde a uma instância de               |
+|       |                  | ``journalmanager.models.Article``.                       |
++-------+------------------+----------------------------------------------------------+
+

--- a/docs/dev/rpc_spec/errno.rst
+++ b/docs/dev/rpc_spec/errno.rst
@@ -21,11 +21,11 @@ Os valores para ``errno`` são:
 +-------+------------------+----------------------------------------------------------+
 | errno | Tipo             | Descrição                                                |
 +=======+==================+==========================================================+
-| 1     | DuplicationError | O artigo representado por ``xml_string`` já havia sido   |
-|       |                  | adicionado anteriormente                                 |
+| 1     | DuplicationError | A entidade não pôde ser criada pois já existe um registro|
+|       |                  | com a mesma chave única.                                 |
 +-------+------------------+----------------------------------------------------------+
-| 2     | ValueError       | ``xml_string`` é mal-formado ou apresenta algum problema |
-|       |                  | estrutural que impeça sua identificação                  |
+| 2     | ValueError       | O valor passado por argumento causou um erro na execução |
+|       |                  | da tarefa.                                               |
 +-------+------------------+----------------------------------------------------------+
 
 

--- a/scielomanager/journalmanager/migrations/0028_auto__add_articleasset.py
+++ b/scielomanager/journalmanager/migrations/0028_auto__add_articleasset.py
@@ -1,0 +1,397 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'ArticleAsset'
+        db.create_table('journalmanager_articleasset', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('article', self.gf('django.db.models.fields.related.ForeignKey')(related_name='assets', to=orm['journalmanager.Article'])),
+            ('file', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
+            ('owner', self.gf('django.db.models.fields.CharField')(default=u'', max_length=1024)),
+            ('use_license', self.gf('django.db.models.fields.TextField')(default=u'')),
+            ('updated_at', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+        ))
+        db.send_create_signal('journalmanager', ['ArticleAsset'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'ArticleAsset'
+        db.delete_table('journalmanager_articleasset')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'journalmanager.aheadpressrelease': {
+            'Meta': {'object_name': 'AheadPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Journal']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.article': {
+            'Meta': {'object_name': 'Article'},
+            'aid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'article_type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'doi': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '2048', 'db_index': 'True'}),
+            'domain_key': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '2048', 'db_index': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_aop': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'issn_epub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issn_ppub': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Issue']"}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'journal_title': ('django.db.models.fields.CharField', [], {'max_length': '512', 'db_index': 'True'}),
+            'related_articles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['journalmanager.Article']", 'null': 'True', 'through': "orm['journalmanager.ArticlesLinkage']", 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'xml': ('scielomanager.custom_fields.XMLSPSField', [], {}),
+            'xml_version': ('django.db.models.fields.CharField', [], {'max_length': '9'})
+        },
+        'journalmanager.articleasset': {
+            'Meta': {'object_name': 'ArticleAsset'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'assets'", 'to': "orm['journalmanager.Article']"}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '1024'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.TextField', [], {'default': "u''"})
+        },
+        'journalmanager.articlecontrolattributes': {
+            'Meta': {'object_name': 'ArticleControlAttributes'},
+            'article': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'control_attributes'", 'unique': 'True', 'to': "orm['journalmanager.Article']"}),
+            'articles_linkage_is_pending': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'es_is_dirty': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'es_updated_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.articleslinkage': {
+            'Meta': {'object_name': 'ArticlesLinkage'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link_to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'referrers'", 'to': "orm['journalmanager.Article']"}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'referrer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links_to'", 'to': "orm['journalmanager.Article']"})
+        },
+        'journalmanager.collection': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Collection'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'collection': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'user_collection'", 'to': "orm['auth.User']", 'through': "orm['journalmanager.UserCollections']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.institution': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Institution'},
+            'acronym': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '16', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {}),
+            'address_complement': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'address_number': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'cel': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'complement': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.issue': {
+            'Meta': {'ordering': "('created', 'id')", 'object_name': 'Issue'},
+            'cover': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_marked_up': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'label': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'blank': 'True'}),
+            'publication_end_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_start_month': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'publication_year': ('django.db.models.fields.IntegerField', [], {}),
+            'section': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Section']", 'symmetrical': 'False', 'blank': 'True'}),
+            'spe_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'suppl_text': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'total_documents': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'regular'", 'max_length': '15'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']", 'null': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'})
+        },
+        'journalmanager.issuetitle': {
+            'Meta': {'object_name': 'IssueTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Issue']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.journal': {
+            'Meta': {'ordering': "('title', 'id')", 'object_name': 'Journal'},
+            'abstract_keyword_languages': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'abstract_keyword_languages'", 'symmetrical': 'False', 'to': "orm['journalmanager.Language']"}),
+            'acronym': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'ccn_code': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64', 'blank': 'True'}),
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'through': "orm['journalmanager.Membership']", 'symmetrical': 'False'}),
+            'copyrighter': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'cover': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'enjoy_creator'", 'to': "orm['auth.User']"}),
+            'ctrl_vocabulary': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'current_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'blank': 'True'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'editor_journal'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'editor_address': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_address_city': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'editor_address_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'editor_address_state': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'editor_address_zip': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'editor_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'editor_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'editor_phone1': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'editor_phone2': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'editorial_standard': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'eletronic_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'final_num': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'final_vol': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'final_year': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4', 'blank': 'True'}),
+            'frequency': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_coverage': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'init_num': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'init_vol': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'init_year': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'is_indexed_aehci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_scie': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_indexed_ssci': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Language']", 'symmetrical': 'False'}),
+            'logo': ('scielomanager.custom_fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'medline_code': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64', 'blank': 'True'}),
+            'medline_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '254', 'blank': 'True'}),
+            'other_previous_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'previous_ahead_documents': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '3', 'blank': 'True'}),
+            'previous_title': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'prev_title'", 'null': 'True', 'to': "orm['journalmanager.Journal']"}),
+            'print_issn': ('django.db.models.fields.CharField', [], {'max_length': '9', 'db_index': 'True'}),
+            'pub_level': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publication_city': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'publisher_country': ('scielo_extensions.modelfields.CountryField', [], {'max_length': '2'}),
+            'publisher_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'publisher_state': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scielo_issn': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'secs_code': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64', 'blank': 'True'}),
+            'short_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'db_index': 'True'}),
+            'sponsor': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'journal_sponsor'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['journalmanager.Sponsor']"}),
+            'study_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals_migration_tmp'", 'null': 'True', 'to': "orm['journalmanager.StudyArea']"}),
+            'subject_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'journals'", 'null': 'True', 'to': "orm['journalmanager.SubjectCategory']"}),
+            'subject_descriptors': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'title_iso': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'}),
+            'twitter_user': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url_journal': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'url_online_submission': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'use_license': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.UseLicense']"})
+        },
+        'journalmanager.journalmission': {
+            'Meta': {'object_name': 'JournalMission'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'missions'", 'to': "orm['journalmanager.Journal']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']", 'null': 'True'})
+        },
+        'journalmanager.journaltimeline': {
+            'Meta': {'object_name': 'JournalTimeline'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'since': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'journalmanager.journaltitle': {
+            'Meta': {'object_name': 'JournalTitle'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'other_titles'", 'to': "orm['journalmanager.Journal']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.language': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Language'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'journalmanager.membership': {
+            'Meta': {'unique_together': "(('journal', 'collection'),)", 'object_name': 'Membership'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'since': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'inprogress'", 'max_length': '16'})
+        },
+        'journalmanager.pendedform': {
+            'Meta': {'object_name': 'PendedForm'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_forms'", 'to': "orm['auth.User']"}),
+            'view_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.pendedvalue': {
+            'Meta': {'object_name': 'PendedValue'},
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'data'", 'to': "orm['journalmanager.PendedForm']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'journalmanager.pressrelease': {
+            'Meta': {'object_name': 'PressRelease'},
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'journalmanager.pressreleasearticle': {
+            'Meta': {'object_name': 'PressReleaseArticle'},
+            'article_pid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'articles'", 'to': "orm['journalmanager.PressRelease']"})
+        },
+        'journalmanager.pressreleasetranslation': {
+            'Meta': {'object_name': 'PressReleaseTranslation'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'press_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'to': "orm['journalmanager.PressRelease']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'journalmanager.regularpressrelease': {
+            'Meta': {'object_name': 'RegularPressRelease', '_ormbases': ['journalmanager.PressRelease']},
+            'issue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'press_releases'", 'to': "orm['journalmanager.Issue']"}),
+            'pressrelease_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.PressRelease']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.section': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Section'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '21', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trashed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'journal': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Journal']"}),
+            'legacy_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'journalmanager.sectiontitle': {
+            'Meta': {'ordering': "['title']", 'object_name': 'SectionTitle'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Language']"}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'titles'", 'to': "orm['journalmanager.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.sponsor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Sponsor', '_ormbases': ['journalmanager.Institution']},
+            'collections': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['journalmanager.Collection']", 'symmetrical': 'False'}),
+            'institution_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['journalmanager.Institution']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'journalmanager.studyarea': {
+            'Meta': {'object_name': 'StudyArea'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'study_area': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'journalmanager.subjectcategory': {
+            'Meta': {'object_name': 'SubjectCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'max_length': '256', 'db_index': 'True'})
+        },
+        'journalmanager.translateddata': {
+            'Meta': {'object_name': 'TranslatedData'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'translation': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.uselicense': {
+            'Meta': {'ordering': "['license_code']", 'object_name': 'UseLicense'},
+            'disclaimer': ('django.db.models.fields.TextField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'license_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'reference_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'journalmanager.usercollections': {
+            'Meta': {'unique_together': "(('user', 'collection'),)", 'object_name': 'UserCollections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['journalmanager.Collection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'journalmanager.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'email_notifications': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tz': ('django.db.models.fields.CharField', [], {'default': "'America/Sao_Paulo'", 'max_length': '150'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['journalmanager']

--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -1468,6 +1468,30 @@ class Article(models.Model):
                 self.aid, domain_key)
 
 
+def articleasset_directory_path(instance, filename):
+    """Indica o diretório de armazenamento dos arquivos de ``ArticleAsset.file``.
+
+    O ativo será armazenado em MEDIA_ROOT/articles/<aid>/assets/<filename>.
+    """
+    return 'articles/{aid}/assets/{filename}'.format(
+            aid=instance.article.aid, filename=filename)
+
+
+class ArticleAsset(models.Model):
+    """Ativo digital vinculado a uma instância de Article.
+    """
+    article = models.ForeignKey('Article', on_delete=models.CASCADE,
+            related_name='assets')
+    file = models.FileField(upload_to=articleasset_directory_path)
+    owner = models.CharField(max_length=1024, default=u'')
+    use_license = models.TextField(default=u'')
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __repr__(self):
+        return u'<%s id="%s" url="%s">' % (self.__class__.__name__,
+                self.pk, self.file.url)
+
+
 # --------------------
 # Callbacks de signals
 # --------------------

--- a/scielomanager/thrift/scielomanager.thrift
+++ b/scielomanager/thrift/scielomanager.thrift
@@ -31,7 +31,7 @@ namespace py scielomanager
  * IMPORTANTE! Alterar o valor de VERSION após qualquer alteração na interface.
  * Regras em: http://semver.org/lang/pt-BR/
  */
-const string VERSION = "1.3.0"
+const string VERSION = "1.4.0"
 
 
 #
@@ -125,6 +125,15 @@ struct AsyncResult {
     2: string value;                  // string codificada em json
 }
 
+/*
+ * ArticleAssetMeta representa metadados associados ao ativo digital, como 
+ * informação de licenciamento por exemplo.
+ */
+struct ArticleAssetMeta {
+    1: optional string owner;
+    2: optional string use_license;
+}
+
 
 service JournalManagerServices {
     /*
@@ -134,6 +143,15 @@ service JournalManagerServices {
      * criada. `task_id` deve ser utilizada para obter o resultado da função. 
      */
     string addArticle(1:string xml_string) throws (1:ServerError srv_err);
+
+    /*
+     * Adiciona um novo ativo digital, vinculado a uma entidade Article.
+     *
+     * Retorna string `task_id` correspondente ao identificador da tarefa
+     * criada. `task_id` deve ser utilizada para obter o resultado da função. 
+     */
+    string addArticleAsset(1:string aid, 2:string filename, 3:binary content, 
+            4:ArticleAssetMeta meta) throws (1:ServerError srv_err);
 
     /*
      * Consulta o resultado da execução de uma determinada tarefa assíncrona.
@@ -160,8 +178,7 @@ service JournalManagerServices {
      * campo `next_batch_id` apresenta o identificador do próximo lote.
      */
     ScanArticlesResults getScanArticlesBatch(1:string batch_id) throws (
-            1:ServerError srv_err, 2:BadRequestError req_err, 
-            3:TimeoutError tou_err); 
+            1:ServerError srv_err, 2:BadRequestError req_err); 
 
 
     #

--- a/scielomanager/thrift/server.py
+++ b/scielomanager/thrift/server.py
@@ -143,3 +143,14 @@ class RPCHandler(object):
     def getInterfaceVersion(self):
         return spec.VERSION
 
+    @resource_cleanup
+    def addArticleAsset(self, aid, filename, content, meta):
+        try:
+            delayed_task = tasks.create_articleasset_from_bytes.delay(
+                    aid, filename, content, meta.owner, meta.use_license)
+            return delayed_task.id
+
+        except Exception as exc:
+            LOGGER.exception(exc)
+            raise spec.ServerError()
+


### PR DESCRIPTION
Closes #1243 

Foi definido o tipo de entidade ``ArticleAsset`` e a função ``addArticleAsset``
na interface thrift, cuja implementação segue a especificação descrita
em ``docs/dev/rpc_spec/addArticleAsset.rst``.

Os ativos são armazenados no diretório base definido na diretiva
``MEDIA_ROOT``, seguidos da estrutura
``articles/<aid>/assets/<filename>``.