### PR TITLE
#1160 - Trocar o separador dos títulos de seções

### DIFF
--- a/scielomanager/journalmanager/models.py
+++ b/scielomanager/journalmanager/models.py
@@ -862,7 +862,7 @@ class Section(models.Model):
     is_trashed = models.BooleanField(_('Is trashed?'), default=False, db_index=True)
 
     def __unicode__(self):
-        return ' / '.join([sec_title.title for sec_title in self.titles.all().order_by('language')])
+        return ' | '.join([sec_title.title for sec_title in self.titles.all().order_by('language')])
 
     @property
     def actual_code(self):

--- a/scielomanager/journalmanager/templates/journalmanager/add_issue.html
+++ b/scielomanager/journalmanager/templates/journalmanager/add_issue.html
@@ -55,6 +55,7 @@
       centerScreen:1,
       width:600,
     });
+    $('#asmSelect0').chosen(defaultChosenOptions)
   });
 </script>
 {% block extra_js %}{% endblock extra_js %}

--- a/scielomanager/journalmanager/tests/tests_models.py
+++ b/scielomanager/journalmanager/tests/tests_models.py
@@ -65,7 +65,7 @@ class SectionTests(MockerTestCase):
         section_title_en.section = section_title.section
         section_title_en.save()
 
-        expected = 'Original Articles / Artigos Originais'
+        expected = 'Original Articles | Artigos Originais'
 
         self.assertEqual(unicode(section_title.section), expected)
 

--- a/scielomanager/validator/tests/doubles.py
+++ b/scielomanager/validator/tests/doubles.py
@@ -3,7 +3,7 @@ import packtools
 # packtools.stylechecker double
 
 
-class XMLValidatorDouble(packtools.XMLValidator):
+class XMLValidatorDouble(object):
     def __init__(self, file, dtd=None, no_doctype=False):
         pass
 


### PR DESCRIPTION
- troca no __unicode__ do modelo journalmanager.Section para um pipe no lugar de barra;
- ajustes na UI para facilitar a seleção no drop down, agora como widget: chosen;
- ajuste no unit test, por causa da troca de slash por pipe;
- ajuste no double importado nos unit test da app validator, para resolver o erro:

> Error when calling the metaclass bases: function() argument 1 must be code, not str

Que apareceu depois da atualização do packtools (eu acho)

#### resultado na interface (formulário de criação de issue)

![screenshot 2016-02-23 12 02 30](https://cloud.githubusercontent.com/assets/805749/13258444/ed2c7f3c-da31-11e5-98bb-706e34297e4e.png)
![screenshot 2016-02-23 12 02 52](https://cloud.githubusercontent.com/assets/805749/13258445/ed4ea45e-da31-11e5-909e-e307e1e1ba62.png)


