### PR TITLE
Permitir valores nulos en use_license

### DIFF
--- a/scielomanager/api/resources_v1.py
+++ b/scielomanager/api/resources_v1.py
@@ -83,7 +83,7 @@ class IssueResource(ModelResource):
     is_press_release = fields.BooleanField(readonly=True)
     suppl_volume = fields.CharField(attribute='volume', readonly=True)
     suppl_number = fields.CharField(attribute='number', readonly=True)
-    use_license = fields.ForeignKey(UseLicenseResource, 'use_license', full=True)
+    use_license = fields.ForeignKey(UseLicenseResource, 'use_license', full=True, null=True)
 
     class Meta(ApiKeyAuthMeta):
         queryset = Issue.objects.all()

--- a/scielomanager/api/resources_v2.py
+++ b/scielomanager/api/resources_v2.py
@@ -128,7 +128,7 @@ class IssueResource(ModelResource):
     thematic_titles = fields.CharField(readonly=True)
     suppl_volume = fields.CharField(attribute='volume', readonly=True)
     suppl_number = fields.CharField(attribute='number', readonly=True)
-    use_license = fields.ForeignKey(UseLicenseResource, 'use_license', full=True)
+    use_license = fields.ForeignKey(UseLicenseResource, 'use_license', full=True, null=True)
 
     class Meta(ApiKeyAuthMeta):
         queryset = models.Issue.objects.all()


### PR DESCRIPTION
Existen valores nulos en el atributo use_license por lo que ocurre el siguiente error al hacer una petición a issues ```http://manager.scielo.org/api/v1/issues/?collection=mexico&format=json```

````

{
    "error": "The model '<Issue: 41 (1)>' has an empty attribute 'use_license' and doesn't allow a null value."
}
```