### PR TITLE
Capacidade de sobrescrever artigos já cadastrados.

### DIFF
--- a/docs/dev/rpc_spec/addArticle.rst
+++ b/docs/dev/rpc_spec/addArticle.rst
@@ -1,7 +1,7 @@
 .. _func-addArticle:
 
-``string addArticle(1:string xml_string) throws (1:ServerError srv_err);``
-==========================================================================
+``string addArticle(1:string xml_string, 2:bool overwrite) throws (1:ServerError srv_err);``
+============================================================================================
 
 Cadastra uma nova entidade ``journalmanager.models.Article``. 
 
@@ -46,6 +46,12 @@ No caso de resultados com status ``FAILURE``, os valores para ``errno`` são:
 | 2     | ValueError       | ``xml_string`` é mal-formado ou apresenta algum problema |
 |       |                  | estrutural que impeça sua identificação                  |
 +-------+------------------+----------------------------------------------------------+
+
+
+.. note:: Erros do tipo ``DuplicationError`` ocorrem apenas em invocações cujo 
+          valor do argumento ``overwrite`` é igual a ``FALSE``. Caso o valor 
+          seja ``TRUE``, a entidade pré-existente será substituída de maneira 
+          permanente.
 
 
 Os elementos de identificação são: 

--- a/scielomanager/thrift/scielomanager.thrift
+++ b/scielomanager/thrift/scielomanager.thrift
@@ -31,7 +31,7 @@ namespace py scielomanager
  * IMPORTANTE! Alterar o valor de VERSION após qualquer alteração na interface.
  * Regras em: http://semver.org/lang/pt-BR/
  */
-const string VERSION = "1.4.0"
+const string VERSION = "2.0.0"
 
 
 #
@@ -142,7 +142,8 @@ service JournalManagerServices {
      * Retorna string `task_id` correspondente ao identificador da tarefa
      * criada. `task_id` deve ser utilizada para obter o resultado da função. 
      */
-    string addArticle(1:string xml_string) throws (1:ServerError srv_err);
+    string addArticle(1:string xml_string, 2:bool overwrite) throws (
+            1:ServerError srv_err);
 
     /*
      * Adiciona um novo ativo digital, vinculado a uma entidade Article.

--- a/scielomanager/thrift/server.py
+++ b/scielomanager/thrift/server.py
@@ -61,9 +61,10 @@ class RPCHandler(object):
     """Implementação do serviço `JournalManagerServices`.
     """
     @resource_cleanup
-    def addArticle(self, xml_string):
+    def addArticle(self, xml_string, overwrite):
         try:
-            delayed_task = tasks.create_article_from_string.delay(xml_string)
+            delayed_task = tasks.create_article_from_string.delay(
+                    xml_string, overwrite_if_exists=overwrite)
             return delayed_task.id
 
         except Exception as exc:


### PR DESCRIPTION
Closes #1264.

A solução proposta modifica a assinatura da função ``addArticle``, da
interface thrift, para receber um segundo argumento posicional chamado
``overwrite`` que indica se é para o servidor tratar duplicatas como
pedidos de substituição.