### PR TITLE
Garantido que não tenha erro ao acesso a API v1 quando uma revista pertence a mais de uma coleção.

### DIFF
--- a/scielomanager/api/tests_resources_v1.py
+++ b/scielomanager/api/tests_resources_v1.py
@@ -342,7 +342,7 @@ class JournalRestAPITest(WebTest):
         journal.join(col, self.user)
 
         response = self.app.get('/api/v1/journals/',
-            extra_environ=self.extra_environ).json
+                                extra_environ=self.extra_environ).json
 
         self.assertEqual(response['objects'][0]['pub_status'], u'inprogress')
 
@@ -361,10 +361,29 @@ class JournalRestAPITest(WebTest):
 
         journal.change_status(col, u'current', u'yeah', self.user)
 
-        response = self.app.get('/api/v1/journals/',
-            extra_environ=self.extra_environ).json
+        response = self.app.get('/api/v1/journals/?collection=%s' % col.name_slug,
+                                extra_environ=self.extra_environ).json
 
         self.assertEqual(response['objects'][0]['pub_status'], u'current')
+
+    def test_dehydrate_pub_status_with_multiple_collections_without_collection_param(self):
+        col = modelfactories.CollectionFactory()
+        col2 = modelfactories.CollectionFactory()
+
+        col.add_user(self.user)
+        col2.add_user(self.user)
+
+        col.make_default_to_user(self.user)
+
+        journal = modelfactories.JournalFactory.create()
+        journal.join(col, self.user)
+        journal.join(col2, self.user, )
+
+        journal.change_status(col, u'current', u'yeah', self.user)
+
+        response = self.app.get('/api/v1/journals/',
+                                extra_environ=self.extra_environ, status=400)
+        self.assertEqual(response.status_code, 400)
 
 
 class CollectionRestAPITest(WebTest):


### PR DESCRIPTION
Atividade realizadas nesse PR: 

Corrigi erro encontrado na API V1 do SciELO Manager ao acessar um periódico que pertence a mais de uma coleção, msg de error:

```
{
error_message: "Sorry, this request could not be processed. Please try again later."
}
```

Alterado a API para garantir que o param ``collection`` seja obrigatório, removido a lógico que obrigava que o periódico seja o default active collection do usuário que acessa a API.

* Alterado o modulo resources_v1.py
* Ajustado teste existentes para essa situação 
* Adicionado testes para garantir retorno no HTTP 400 (BadRequest) 👍 


