### PR TITLE
#1286 - Trocar title_iso por short_title nos arquivos exportados *_issue.mds

### DIFF
--- a/scielomanager/export/markupfile.py
+++ b/scielomanager/export/markupfile.py
@@ -98,9 +98,9 @@ class Issue(object):
 
     @property
     def legend(self):
-        return u'{0} v.{1} n.{2}'.format(self._issue.journal.title_iso,
-                                unicode(self._issue.volume),
-                                unicode(self._issue.identification))
+        return u'{0} v.{1} n.{2}'.format(self._issue.journal.short_title,
+                                         unicode(self._issue.volume),
+                                         unicode(self._issue.identification))
 
     @property
     def period(self):

--- a/scielomanager/export/tests/tests_markupfiles.py
+++ b/scielomanager/export/tests/tests_markupfiles.py
@@ -293,7 +293,7 @@ class IssueTests(MockerTestCase):
         dummy_issue.identification
         self.mocker.result('3')
 
-        dummy_journal.title_iso
+        dummy_journal.short_title
         self.mocker.result('Star Wars')
 
         self.mocker.replay()
@@ -337,7 +337,7 @@ class IssueTests(MockerTestCase):
         dummy_issue.journal
         self.mocker.result(dummy_journal)
 
-        dummy_journal.title_iso
+        dummy_journal.short_title
         self.mocker.result('Star Wars')
 
         dummy_issue.volume


### PR DESCRIPTION
FIX: #1286