### PR TITLE
Normaliza dados do periódico para número regular e AOP nos pacotes do Markup.

### DIFF
--- a/scielomanager/export/markupfile.py
+++ b/scielomanager/export/markupfile.py
@@ -273,7 +273,7 @@ class JournalStandard(L10nIssue):
     def journal_meta(self):
         return '#'.join([
             self.issn,
-            self.abbrev_title,
+            self.short_title,
             self.norma,
             self.pub_type,
             self.issn,
@@ -482,7 +482,7 @@ class JournalStandardAhead(L10nAhead):
 
     @property
     def title(self):
-        return unicode(self._journal.short_title)
+        return unicode(self._journal.title)
 
     @property
     def acron(self):
@@ -499,7 +499,7 @@ class JournalStandardAhead(L10nAhead):
     def journal_meta(self):
         return '#'.join([
             self.issn,
-            self.title,
+            self.short_title,
             self.norma,
             self.pub_type,
             self.issn,

--- a/scielomanager/export/tests/tests_markupfiles.py
+++ b/scielomanager/export/tests/tests_markupfiles.py
@@ -529,7 +529,7 @@ class JournalStandardTests(MockerTestCase):
         dummy_issue.journal
         self.mocker.result(dummy_journal)
 
-        dummy_journal.title_iso
+        dummy_journal.short_title
         self.mocker.result(u'blitz')
 
         dummy_journal.editorial_standard
@@ -1345,7 +1345,7 @@ class JournalStandardAheadTests(MockerTestCase):
     def test_title_is_the_journal_title(self):
         dummy_journal = self.mocker.mock()
 
-        dummy_journal.short_title
+        dummy_journal.title
         self.mocker.result(u'foo')
 
         self.mocker.replay()
@@ -1359,9 +1359,13 @@ class JournalStandardAheadTests(MockerTestCase):
         dummy_journal = self.mocker.mock()
         dummy_study_area = self.mocker.mock()
 
+        dummy_journal.title
+        self.mocker.result(u'foo')
+        self.mocker.count(1)
+
         dummy_journal.short_title
         self.mocker.result(u'foo')
-        self.mocker.count(2)
+        self.mocker.count(1)
 
         dummy_journal.editorial_standard
         self.mocker.result('apa')


### PR DESCRIPTION
Aplica as modificações descritas no ticket
https://github.com/scieloorg/scielo-manager/issues/1286

Fixes #1413